### PR TITLE
Be smarter with django requirements version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -181,6 +181,6 @@ setup(
         "Framework :: Django",
     ],
     install_requires=[
-        "Django",
+        "Django>=1.3",
     ],
 )


### PR DESCRIPTION
Since Feb. 26, 2013 Django 1.5 has been released, so if you say that your module requires Django, setup will automatically install 1.5.
If it's convenient for new project that's not the case for old one's...
In this case best options are to require a decent version of Django for which we are sure django-select2 is fully compatible.
In this pull request I've set it to Django>=1.3 
Another option is to remove django requirement as it let user make their own choice.
