### PR TITLE
Fix importerror under django1.6

### DIFF
--- a/django_select2/urls.py
+++ b/django_select2/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 from .views import AutoResponseView
 


### PR DESCRIPTION
When I installed dev version of django, this `ImportError: No module named defaults` raises.

`django.conf.urls.defaults` has been removed, use `django.conf.urls` instead.
