### PR TITLE
Removed empty term validation.

### DIFF
--- a/django_select2/views.py
+++ b/django_select2/views.py
@@ -56,8 +56,6 @@ class Select2View(JSONResponseMixin, View):
             term = request.GET.get('term', None)
             if term is None:
                 return self.render_to_response(self._results_to_context(('missing term', False, [], )))
-            if not term:
-                return self.render_to_response(self._results_to_context((NO_ERR_RESP, False, [], )))
 
             try:
                 page = int(request.GET.get('page', None))


### PR DESCRIPTION
Why are you validating that term is filled? If I want to suggest values immediately after opening select2 input, I specify `select2_options={"minimumResultsForSearch": 0, "minimumInputLength": 0}`.

Why isn't this valid case? Maybe I'm missing something, but see it very useful to suggest, for example, last used values immediately after opening select2 field.

Thanks!
