### PR TITLE
Adds instruction for including in urlconf

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ Installation
 3. When deploying on production server, run :-
 
         python manage.py collectstatic
+        
+4. Add `django_select` to your urlconf for Ajax support
+   
+        url(r'^select2/', include('django_select2.urls')),
+
 
 Documentation
 =============


### PR DESCRIPTION
I received an error `Reverse for 'django_select2_central_json' with arguments '()' and keyword arguments '{}' not found.`, and found an answer [here](Reverse for 'django_select2_central_json' with arguments '%28)' and keyword arguments '{}' not found.)

Presumably everybody needs to include this in the urlconf, as I'm just using the basic fields you've provided.

Nice work on this package!
