### PR TITLE
Allow select2 fields to be chained using the filter_by widget option

### DIFF
--- a/django_select2/fields.py
+++ b/django_select2/fields.py
@@ -147,11 +147,11 @@ class ModelResultJsonMixin(object):
     def get_queryset(self):
         """
         Returns the queryset.
-        
+
         The default implementation returns the ``self.queryset``, which is usually the
         one set by sub-classes at class-level. However, if that is ``None``
         then ``ValueError`` is thrown.
-        
+
         :return: queryset
         :rtype: :py:class:`django.db.models.query.QuerySet`
         """
@@ -185,7 +185,7 @@ class ModelResultJsonMixin(object):
         """
         return {}
 
-    def prepare_qs_params(self, request, search_term, search_fields):
+    def prepare_qs_params(self, request, search_term, search_fields, filter_by):
         """
         Prepares queryset parameter to use for searching.
 
@@ -248,9 +248,16 @@ class ModelResultJsonMixin(object):
                 q = Q(**kwargs)
             else:
                 q = q | Q(**kwargs)
-        return {'or': [q], 'and': {}}
 
-    def get_results(self, request, term, page, context):
+        params = {'or': [q], 'and': {}}
+
+        if filter_by:
+            related_name = self.widget.filter_by['related_name']
+            params['and'][related_name] = filter_by
+
+        return params
+
+    def get_results(self, request, term, page, context, filter_by):
         """
         See :py:meth:`.views.Select2View.get_results`.
 
@@ -260,7 +267,7 @@ class ModelResultJsonMixin(object):
             raise ValueError('search_fields is required.')
 
         qs = copy.deepcopy(self.get_queryset())
-        params = self.prepare_qs_params(request, term, self.search_fields)
+        params = self.prepare_qs_params(request, term, self.search_fields, filter_by)
 
         if self.max_results:
             min_ = (page - 1) * self.max_results
@@ -389,7 +396,7 @@ class ModelChoiceFieldMixin(QuerysetChoiceMixin):
         # by other codes. If new args are added to Field then make sure they are added here too.
         kargs = extract_some_key_val(kwargs, [
             'empty_label', 'cache_choices', 'required', 'label', 'initial', 'help_text',
-            'validators', 'localize',
+            'validators', 'localize'
             ])
         kargs['widget'] = kwargs.pop('widget', getattr(self, 'widget', None))
         kargs['to_field_name'] = kwargs.pop('to_field_name', 'pk')
@@ -758,7 +765,7 @@ class HeavyModelSelect2TagField(HeavySelect2FieldBaseMixin, ModelMultipleChoiceF
     def get_model_field_values(self, value):
         """
         This is called when the input value is not valid and the field
-        tries to create a new model instance. 
+        tries to create a new model instance.
 
         :param value: Invalid value entered by the user.
         :type value: unicode
@@ -846,7 +853,7 @@ class AutoModelSelect2TagField(ModelResultJsonMixin, AutoViewFieldMixin, HeavyMo
     .. warning:: :py:exc:`NotImplementedError` would be thrown if :py:meth:`get_model_field_values` is not implemented.
 
     Example::
-    
+
         class Tag(models.Model):
             tag = models.CharField(max_length=10, unique=True)
             def __unicode__(self):

--- a/django_select2/static/js/heavy_data.js
+++ b/django_select2/static/js/heavy_data.js
@@ -6,10 +6,13 @@ if (!window['django_select2']) {
 												// since this can't be entered by user.
 		get_url_params: function (term, page, context) {
 			var field_id = jQuery(this).data('field_id'),
+                            filter_by_id = jQuery(this).data('filter_by'),
+                            filter_by = jQuery('#' + filter_by_id).val(),
 				res = {
 					'term': term,
 					'page': page,
-					'context': context
+					'context': context,
+					'filter': filter_by
 				};
 			if (field_id) {
 				res['field_id'] = field_id;
@@ -59,14 +62,14 @@ if (!window['django_select2']) {
 		updateText: function ($e) {
 			var val = $e.select2('val'), data = $e.select2('data'), txt = $e.txt(), isMultiple = !!$e.attr('multiple'),
 				diff;
-			
+
 			if (val || val === 0) { // Means value is set. A numerical 0 is also a valid value.
 				if (isMultiple) {
 					if (val.length !== txt.length) {
 						txt = [];
 						jQuery(val).each(function (idx) {
 							var i, value = this, id;
-							
+
 							for (i in data) {
 								id = data [i].id;
 								if (id instanceof String) {
@@ -109,12 +112,12 @@ if (!window['django_select2']) {
 						return [val, txt];
 					}
 				}
-				
+
 				if (res) {
 					txt = [];
 					jQuery(val).each(function (idx) {
 						var i, value = this;
-						
+
 						for (i in res) {
 							if (res[i].id == value) {
 								val[idx] = res[i].id; // To set it to correct data type.

--- a/django_select2/views.py
+++ b/django_select2/views.py
@@ -66,12 +66,13 @@ class Select2View(JSONResponseMixin, View):
             if page == -1:
                 return self.render_to_response(self._results_to_context(('bad page no.', False, [], )))
             context = request.GET.get('context', None)
+            filter_by = request.GET.get('filter', None)
         else:
             return self.render_to_response(self._results_to_context(('not a get request', False, [], )))
 
         return self.render_to_response(
             self._results_to_context(
-                self.get_results(request, term, page, context)
+                self.get_results(request, term, page, context, filter_by)
                 )
             )
 
@@ -125,7 +126,7 @@ class Select2View(JSONResponseMixin, View):
         """
         pass
 
-    def get_results(self, request, term, page, context):
+    def get_results(self, request, term, page, context, filter_by):
         """
         Returns the result for the given search ``term``.
 
@@ -186,9 +187,7 @@ class AutoResponseView(Select2View):
 
         request.__django_select2_local = field
 
-    def get_results(self, request, term, page, context):
+    def get_results(self, request, term, page, context, filter_by):
         field = request.__django_select2_local
         del request.__django_select2_local
-        return field.get_results(request, term, page, context)
-
-
+        return field.get_results(request, term, page, context, filter_by)

--- a/django_select2/widgets.py
+++ b/django_select2/widgets.py
@@ -384,6 +384,7 @@ class HeavySelect2Mixin(Select2Mixin):
         self.url = kwargs.pop('data_url', None)
         self.userGetValTextFuncName = kwargs.pop('userGetValTextFuncName', u'null')
         self.choices = kwargs.pop('choices', [])
+        self.filter_by = kwargs.pop('filter_by', None)
 
         if not self.view and not self.url:
             raise ValueError('data_view or data_url is required')
@@ -599,6 +600,8 @@ class AutoHeavySelect2Mixin(object):
 
     def render_inner_js_code(self, id_, *args):
         js = u"$('#%s').data('field_id', '%s');" % (id_, self.field_id)
+        if self.filter_by:
+            js += u"$('#%s').data('filter_by', '%s');" % (id_, self.filter_by['id'])
         js += super(AutoHeavySelect2Mixin, self).render_inner_js_code(id_, *args)
         return js
 


### PR DESCRIPTION
This allows someone to chain multiple in-page select2 fields.

In my use case, I'm filtering state by country, and city by state as the user selects.

    country = CountryChoices(
        label='Country',
        widget=AutoHeavySelect2Widget(
            select2_options={
                'placeholder': u"Country"
            }
        ))
    state = StateChoices(
        label='State',
        widget=AutoHeavySelect2Widget(
            filter_by={
                'id': 'id_country',
                'related_name': 'country'
            },
            select2_options={
                'placeholder': u"State"
            }
        ))
    city = CityChoices(
        label='City',
        widget=AutoHeavySelect2Widget(
            filter_by={
                'id': 'id_state',
                'related_name': 'region'
            },
            select2_options={
                'placeholder': u"City"
            }
        ))

Let me know if there is a cleaner way to integrate this option. Referencing the id seems like it could be improved. Maybe there's a better place to put these, rather than the widget.