### PR TITLE
added '.distinct()' to result query on ModelJsonMixin

### DIFF
--- a/django_select2/fields.py
+++ b/django_select2/fields.py
@@ -265,12 +265,12 @@ class ModelResultJsonMixin(object):
         if self.max_results:
             min_ = (page - 1) * self.max_results
             max_ = min_ + self.max_results + 1  # fetching one extra row to check if it has more rows.
-            res = list(qs.filter(*params['or'], **params['and'])[min_:max_])
+            res = list(qs.filter(*params['or'], **params['and']).distinct()[min_:max_])
             has_more = len(res) == (max_ - min_)
             if has_more:
                 res = res[:-1]
         else:
-            res = list(qs.filter(*params['or'], **params['and']))
+            res = list(qs.filter(*params['or'], **params['and']).distinct())
             has_more = False
 
         res = [(getattr(obj, self.to_field_name), self.label_from_instance(obj), self.extra_data_from_instance(obj))


### PR DESCRIPTION
When using `django-select2`, I noticed that when using my `AutoModelSelect2Field`, I was ending up with the same object showing up multiple times in the result list.

My field looked as follows:

``` python
class CampusSelectField(AutoModelSelect2Field):
    queryset = Campus.objects.all()
    search_fields = ['domain_set__domain__iexact', 'aliases__name__icontains', 'IPEDS_unitid__exact']
    to_field = 'name'
```

The reason for the duplicates is that sometimes the same item would be matched in multiple search fields, or even multiple times within `aliases__name__icontains`, matching multiple aliases.

I added the `.distinct()` command to the mixin to prevent this.
