### PR TITLE
Remove unnecessary db request

### DIFF
--- a/django_select2/fields.py
+++ b/django_select2/fields.py
@@ -302,7 +302,7 @@ class UnhideableQuerysetType(type):
 
     def __call__(cls, *args, **kwargs):
         queryset = kwargs.get('queryset', None)
-        if not queryset and hasattr(cls, '_subclass_queryset'):
+        if queryset is None and hasattr(cls, '_subclass_queryset'):
             kwargs['queryset'] = getattr(cls, '_subclass_queryset')
         return type.__call__(cls, *args, **kwargs)
 


### PR DESCRIPTION
We have no db server on the build server.
When I had tried to collect static I saw this error:
    django.db.utils.OperationalError: could not connect to server: Connection refused
        Is the server running on host "127.0.0.1" and accepting
        TCP/IP connections on port 5432?
Full stacktrace: http://pastebin.com/xx7Te8HS
This fix will remove useless query to database server.
