### PR TITLE
HeavyModelSelect2TagField

### DIFF
--- a/django_select2/widgets.py
+++ b/django_select2/widgets.py
@@ -601,6 +601,21 @@ class HeavySelect2TagWidget(HeavySelect2MultipleWidget):
         self.options['tokenSeparators'] = [",", " "]
         self.options['createSearchChoice'] = '*START*django_select2.createSearchChoice*END*'
 
+    def render_inner_js_code(self, id_, *args):
+        fieldset_id = re.sub(r'-\d+-', '_', id_).replace('-', '_')
+        if '__prefix__' in id_:
+            return ''
+        else:
+            js = u'''
+                  window.django_select2.%s = function (selector, fieldID) {
+                    var hashedSelector = "#" + selector;
+                    $(hashedSelector).data("field_id", fieldID);
+                  ''' % (fieldset_id)
+            js += super(HeavySelect2TagWidget, self).render_inner_js_code(id_, *args)
+            js += '};'
+            js += 'django_select2.%s("%s", "%s");' % (fieldset_id, id_, id_)
+            return js
+
 
 ### Auto Heavy widgets ###
 

--- a/testapp/testapp/templates/list.html
+++ b/testapp/testapp/templates/list.html
@@ -9,9 +9,17 @@
 	<a href="{% url create_new_href %}">Create New</a>
 	<br/>
 {% endif %}
+<p>Auto Tags</p>
 <ul>
     {% for e in object_list %}
         <li><a href="{% url href e.id %}">{{ e }}</a></li>
     {% endfor %}
 </ul>
+<p>Non-Auto Tags</p>
+<ul>
+    {% for e in object_list %}
+        <li><a href="{% url href_non_auto e.id %}">{{ e }}</a></li>
+    {% endfor %}
+</ul>
+
 </body>

--- a/testapp/testapp/testmain/forms.py
+++ b/testapp/testapp/testmain/forms.py
@@ -175,7 +175,7 @@ class QuestionNonAutoForm(forms.ModelForm):
     description = forms.CharField(widget=forms.Textarea)
     tags = TagNAField(queryset=Tag.objects,
             search_fields=['tag__icontains'],
-            widget = HeavySelect2TagWidget(data_url='http://localhost:8000/test/question/tags/'))
+            widget = HeavySelect2TagWidget(data_view='test_tagging_tags'))
 
     class Meta:
         model = Question

--- a/testapp/testapp/testmain/forms.py
+++ b/testapp/testapp/testmain/forms.py
@@ -39,6 +39,10 @@ class TagField(AutoModelSelect2TagField):
     def get_model_field_values(self, value):
         return {'tag': value}
 
+class TagNAField(HeavyModelSelect2TagField):
+    def get_model_field_values(self, value):
+        return {'tag': value}
+
 class SelfChoices(AutoSelect2Field):
     def get_val_txt(self, value):
         if not hasattr(self, 'res_map'):
@@ -162,6 +166,16 @@ class QuestionForm(forms.ModelForm):
     question = forms.CharField()
     description = forms.CharField(widget=forms.Textarea)
     tags = TagField()
+
+    class Meta:
+        model = Question
+
+class QuestionNonAutoForm(forms.ModelForm):
+    question = forms.CharField()
+    description = forms.CharField(widget=forms.Textarea)
+    tags = TagNAField(queryset=Tag.objects,
+            search_fields=['tag__icontains'],
+            widget = HeavySelect2TagWidget(data_url='http://localhost:8000/test/question/tags/'))
 
     class Meta:
         model = Question

--- a/testapp/testapp/testmain/urls.py
+++ b/testapp/testapp/testmain/urls.py
@@ -13,7 +13,9 @@ urlpatterns = patterns('testapp.testmain.views',
 
     url(r'question/$', 'test_list_questions', name='test_list_questions'),
     url(r'question/form/([0-9]+)/$', 'test_tagging', name='test_tagging'),
+    url(r'question/form/([0-9]+)/na/$', 'test_tagging_non_auto', name='test_tagging_non_auto'),
     url(r'question/form/$', 'test_tagging_new', name='test_tagging_new'),
+    url(r'question/tags/$', 'test_tagging_tags', name='test_tagging_tags'),
 
     url(r'auto_model/form/$', 'test_auto_multivalue_field', name='test_auto_multivalue_field'),
 

--- a/testapp/testapp/testmain/views.py
+++ b/testapp/testapp/testmain/views.py
@@ -1,10 +1,11 @@
+import json
 from django.core.urlresolvers import reverse
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, HttpResponse
 from django.shortcuts import render, get_object_or_404
 
-from .forms import EmployeeForm, DeptForm, MixedForm, InitialValueForm, QuestionForm, WordsForm, SchoolForm, GetSearchTestForm, \
-    AnotherWordForm
-from .models import Employee, Dept, Question, WordList, School
+from .forms import EmployeeForm, DeptForm, MixedForm, InitialValueForm, QuestionForm, QuestionNonAutoForm, WordsForm, SchoolForm, \
+    GetSearchTestForm, AnotherWordForm
+from .models import Employee, Dept, Question, WordList, School, Tag
 
 def test_single_value_model_field(request):
     return render(request, 'list.html', {
@@ -60,6 +61,7 @@ def test_list_questions(request):
     return render(request, 'list.html', {
         'title': 'Questions',
         'href': 'test_tagging',
+        'href_non_auto': 'test_tagging_non_auto',
         'object_list': Question.objects.all(),
         'create_new_href': 'test_tagging_new'
     })
@@ -80,6 +82,25 @@ def test_tagging(request, id):
     else:
         form = QuestionForm(instance=question)
     return render(request, 'form.html', {'form': form})
+
+def test_tagging_non_auto(request, id):
+    if id is None:
+        question = Question()
+    else:
+        question =  get_object_or_404(Question, pk=id)
+    if request.POST:
+        form = QuestionNonAutoForm(data=request.POST, instance=question)
+        if form.is_valid():
+            form.save()
+            return HttpResponseRedirect(reverse('home'))
+    else:
+        form = QuestionNonAutoForm(instance=question)
+    return render(request, 'form.html', {'form': form})
+
+def test_tagging_tags(request):
+    tags = Tag.objects.all()
+    results = [{'id': t.id, 'text': t.tag} for t in tags]
+    return HttpResponse(json.dumps({'err': 'nil', 'results': results}), content_type='application/json')
 
 def test_auto_multivalue_field(request):
     try:


### PR DESCRIPTION
Add a test for HeavyModelSelect2TagField in the testapp.

The labels for selected options aren't displayed correctly in the test - I updated HeavySelect2TagWidget to override render_inner_js_code, and now it seems to work properly.