### PR TITLE
Fix - use selector instead of js var when rendering field

### DIFF
--- a/django_select2/widgets.py
+++ b/django_select2/widgets.py
@@ -218,8 +218,7 @@ class Select2Mixin(object):
         """
         options = json.dumps(self.get_options())
         options = options.replace('"*START*', '').replace('*END*"', '')
-        # selector variable must already be passed to this
-        return u'$(hashedSelector).select2(%s);' % (options)
+        return u'$("#%s").select2(%s);' % (id_, options)
 
     def render(self, name, value, attrs=None, choices=()):
         """


### PR DESCRIPTION
When the Select2Widget is rendered it doesn't output the hashedSelector JS var to be used with the select2 function causing JS errors. This fix probably isn't the correct implementation but fixes the issue for me on ModelSelect2Fields.