### PR TITLE
relative import fix

### DIFF
--- a/django_select2/memcache_wrapped_db_client.py
+++ b/django_select2/memcache_wrapped_db_client.py
@@ -8,11 +8,11 @@ class Client(object):
 
     def __init__(self, hostname="127.0.0.1", port="11211", expiry=900):
         if hostname and port:
-            import memcache_client
+            from . import memcache_client
 
             self.cache = memcache_client.Client(hostname, port, expiry)
 
-        import db_client
+        from . import db_client
 
         self.db = db_client.Client()
 

--- a/django_select2/util.py
+++ b/django_select2/util.py
@@ -78,7 +78,7 @@ def is_valid_id(val):
 
 
 if ENABLE_MULTI_PROCESS_SUPPORT:
-    from memcache_wrapped_db_client import Client
+    from .memcache_wrapped_db_client import Client
 
     remote_server = Client(MEMCACHE_HOST, binary_type(MEMCACHE_PORT), MEMCACHE_TTL)
 


### PR DESCRIPTION
Fixing some in-function relative imports that would fail because of
    `from __future__ import absolute_import` 

Specifically for me it  would fail bacause of
ENABLE_SELECT2_MULTI_PROCESS_SUPPORT = True

Also would be good to cover such cases in testes