### PR TITLE
django1.8 compatibility issues

### DIFF
--- a/django_select2/fields.py
+++ b/django_select2/fields.py
@@ -24,6 +24,11 @@ from .widgets import (AutoHeavySelect2MultipleWidget,
                       HeavySelect2MultipleWidget, HeavySelect2TagWidget,
                       HeavySelect2Widget, Select2MultipleWidget, Select2Widget)
 
+try:
+    from django.forms.fields import RenameFieldMethods as UnhideableQuerysetTypeBase
+except ImportError:
+    UnhideableQuerysetTypeBase = type
+
 logger = logging.getLogger(__name__)
 
 
@@ -284,7 +289,7 @@ class ModelResultJsonMixin(object):
         return NO_ERR_RESP, has_more, res
 
 
-class UnhideableQuerysetType(type):
+class UnhideableQuerysetType(UnhideableQuerysetTypeBase):
     """
     This does some pretty nasty hacky stuff, to make sure users can
     also define ``queryset`` as class-level field variable, instead of

--- a/django_select2/models.py
+++ b/django_select2/models.py
@@ -9,7 +9,7 @@ from django.utils.encoding import force_text, python_2_unicode_compatible
 class KeyMap(models.Model):
     key = models.CharField(max_length=40, unique=True)
     value = models.CharField(max_length=100)
-    accessed_on = models.DateTimeField(auto_now_add=True, auto_now=True)
+    accessed_on = models.DateTimeField(auto_now=True)
 
     def __str__(self):
         return force_text("%s => %s" % (self.key, self.value))


### PR DESCRIPTION
django1.8 does not allow simultaneous usage of auto_now and auto_now_add, but auto_now have effect of auto_now_add too, so there should not be problems

And fields have RenameFieldMethods as their metaclass, so we must use it too