### PR TITLE
Select2Mixin hashedSelector fix, with test

### DIFF
--- a/django_select2/widgets.py
+++ b/django_select2/widgets.py
@@ -184,8 +184,9 @@ class Select2Mixin(object):
         """
         options = json.dumps(self.get_options())
         options = options.replace('"*START*', '').replace('*END*"', '')
-        # selector variable must already be passed to this
-        return '$(hashedSelector).select2(%s);' % (options)
+        js = 'var hashedSelector = "#" + "%s";' % id_
+        js += '$(hashedSelector).select2(%s);' % (options)
+        return js
 
     def render(self, name, value, attrs=None, choices=()):
         """

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -25,8 +25,11 @@ class TestSelect2Widget(object):
 
     def test_selecting(self, db, client, live_server, driver):
         driver.get(live_server + self.url)
+        dropdown = driver.find_element_by_css_selector('.select2-results')
+        assert dropdown.is_displayed() is False
+        elem = driver.find_element_by_css_selector('.select2-choice')
+        elem.click()
+        assert dropdown.is_displayed() is True
         with pytest.raises(NoSuchElementException):
             error = driver.find_element_by_xpath('//body[@JSError]')
             pytest.fail(error.get_attribute('JSError'))
-        elem = driver.find_element_by_id('s2id_id_number')
-        elem.click()

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,6 +1,10 @@
 # -*- coding:utf-8 -*-
 from __future__ import print_function, unicode_literals
 
+import pytest
+from django.core.urlresolvers import reverse
+from selenium.common.exceptions import NoSuchElementException
+
 
 class TestWidgets(object):
     url = ""
@@ -14,3 +18,15 @@ class TestWidgets(object):
         from django_select2.widgets import HeavySelect2Widget
         new_widget = HeavySelect2Widget(data_url="/")
         assert new_widget.is_hidden is False
+
+
+class TestSelect2Widget(object):
+    url = reverse('select2_widget')
+
+    def test_selecting(self, db, client, live_server, driver):
+        driver.get(live_server + self.url)
+        with pytest.raises(NoSuchElementException):
+            error = driver.find_element_by_xpath('//body[@JSError]')
+            pytest.fail(error.get_attribute('JSError'))
+        elem = driver.find_element_by_id('s2id_id_number')
+        elem.click()

--- a/tests/testapp/forms/__init__.py
+++ b/tests/testapp/forms/__init__.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, unicode_literals
 from django import forms
 
 from django_select2.fields import Select2MultipleWidget
+from django_select2.widgets import Select2Widget
 
 from tests.testapp import models
 from . import fields
@@ -51,3 +52,11 @@ class AlbumModelForm(forms.ModelForm):
 class AlbumForm(forms.Form):
     title = forms.CharField(max_length=255)
     artist = fields.ArtistField()
+
+
+class Select2WidgetForm(forms.Form):
+    NUMBER_CHOICES = [ (1, 'One'),
+                       (2, 'Two'),
+                       (3, 'Three'),
+                       (4, 'Four') ]
+    number = forms.ChoiceField(widget=Select2Widget(), choices=NUMBER_CHOICES)

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -3,11 +3,13 @@ from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import include, patterns, url
 
-from .forms import ArtistForm
+from .forms import ArtistForm, Select2WidgetForm
 from .views import TemplateFormView
 
 urlpatterns = patterns(
     '',
+    url(r'select2_widget',
+        TemplateFormView.as_view(form_class=Select2WidgetForm), name='select2_widget'),
     url(r'single_value_model_field',
         TemplateFormView.as_view(form_class=ArtistForm), name='single_value_model_field'),
 


### PR DESCRIPTION
There's already been action on this error: PR #158, issue #154. In this PR, though, I added a test that failed with the "undefined hashedSelector" javascript error, and now it passes with the fix (from issue #154).

Note: I'm not completely sure this won't break other Widgets, but at least we have a test for Select2Widget while we fix the others if needed.