### PR TITLE
return list of css links instead of generator

### DIFF
--- a/django_select2/media.py
+++ b/django_select2/media.py
@@ -53,4 +53,4 @@ def get_select2_css_libs(light=False):
                 css_files = ('css/select2.min.css',)
             else:
                 css_files = ('css/all.min.css',)
-    return (django_select2_static(f) for f in css_files)
+    return [django_select2_static(f) for f in css_files]


### PR DESCRIPTION
Fixes problem when media of form instance uses twice or more for one request. For example, for separately render ``{{ form.media.js }}`` and ``{{ form.medis.css }}`` values.
Generator allow only one iteration over it's items:
```
>>> l = [1, 2, 3]
>>> gen = (i for i in l)
>>> gen
<generator object <genexpr> at 0x103ce73c0>
>>> [i for i in gen]
[1, 2, 3]
>>> [i for i in gen]
[]
```