### PR TITLE
Make static work with CachedStaticFilesStorage

### DIFF
--- a/django_select2/media.py
+++ b/django_select2/media.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.templatetags.static import static
+from django.contrib.staticfiles.templatetags.staticfiles import static
 
 from . import __BOOTSTRAP as BOOTSTRAP
 


### PR DESCRIPTION
`django.templatetags.static.static` doesn't return the hashed URL, but `django.contrib.staticfiles.templatetags.staticfiles.static` does.

This pull request changes `django_select2_static` to use the latter.