### PR TITLE
Javascript

### DIFF
--- a/django_select2/conf.py
+++ b/django_select2/conf.py
@@ -49,5 +49,13 @@ class Select2Conf(AppConf):
     It has set `select2_` as a default value, which you can change if needed.
     """
 
+    MEDIA_PREFIX = getattr(settings, 'SELECT2_MEDIA_PREFIX', '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/')
+    """
+    Normally external referenced JavaScript and StyleSheet files are loaded using a CDN. This may be
+    unacceptable for some kind of applications, where no Internet connection is available.
+    In settings.py, use ``SELECT2_MEDIA_PREFIX`` to override the location where external JS and CSS
+    media files shall be loaded from.
+    """
+
     class Meta:
         prefix = 'SELECT2'

--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -101,9 +101,9 @@ class Select2Mixin(object):
             https://docs.djangoproject.com/en/1.8/topics/forms/media/#media-as-a-dynamic-property
         """
         return forms.Media(
-            js=('//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js',
+            js=(settings.SELECT2_MEDIA_PREFIX + 'js/select2.min.js',
                 'django_select2/django_select2.js'),
-            css={'screen': ('//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css',)}
+            css={'screen': (settings.SELECT2_MEDIA_PREFIX + 'css/select2.min.css',)}
         )
 
     media = property(_get_media)

--- a/django_select2/static/django_select2/django_select2.js
+++ b/django_select2/static/django_select2/django_select2.js
@@ -1,4 +1,4 @@
-django.jQuery(function($) {
+jQuery(function($) {
     $('.django-select2').not('django-select2-heavy').select2();
     $('.django-select2.django-select2-heavy').each(function () {
         var field_id = $(this).data('field_id');

--- a/django_select2/static/django_select2/django_select2.js
+++ b/django_select2/static/django_select2/django_select2.js
@@ -1,4 +1,4 @@
-$(function () {
+django.jQuery(function($) {
     $('.django-select2').not('django-select2-heavy').select2();
     $('.django-select2.django-select2-heavy').each(function () {
         var field_id = $(this).data('field_id');


### PR DESCRIPTION
It would be great if the include path for external js/css files is configurable.

Additionally, you should not relay on ``$`` as a globally available symbol. Django offers its own singleton object, ``django.jQuery``. This avoids to include ``jquery.js`` a second time into the project.