### PR TITLE
don't evaluate queryset

### DIFF
--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -351,7 +351,7 @@ class ModelSelect2Mixin(object):
         :return: Filtered queryset
         :rtype: :class:`.django.db.models.QuerySet`
         """
-        if not queryset:
+        if queryset is None:
             queryset = self.get_queryset()
         search_fields = self.get_search_fields()
         select = Q()


### PR DESCRIPTION
ref https://github.com/applegrew/django-select2/issues/231
here we only care if queryset is not set

