### PR TITLE
New feature - Allow choice of location for Select2.js & Select2.css

### DIFF
--- a/django_select2/conf.py
+++ b/django_select2/conf.py
@@ -66,14 +66,14 @@ class Select2Conf(AppConf):
 
         SELECT2_CSS_LIB_FILE = 'assets/css/select2-4.0.1.css.js'
     """
-    JS_MEDIA = (getattr(settings, 'SELECT2_JS_LIB_FILE', JS_LIB_FILE), 'django_select2/django_select2.js')
+    JS_MEDIA = None
     """
     The configuration provided for ``js`` to the ``media`` attibute of the ``Select2Mixin``.
 
     .. note:: If you need to change this, we assume you have read the code and know
         what you are doing.
     """
-    CSS_MEDIA = {'screen': (getattr(settings, 'SELECT2_CSS_LIB_FILE', CSS_LIB_FILE), )}
+    CSS_MEDIA = None
     """
     The configuration provided for ``css`` to the ``media`` attibute of the ``Select2Mixin``.
 

--- a/django_select2/conf.py
+++ b/django_select2/conf.py
@@ -52,7 +52,7 @@ class Select2Conf(AppConf):
     """
     The URI for the Select2 JS file. By default this points to the Cloudflare CDN.
 
-    If you want to select the version of the JS library used, or want to serve it from 
+    If you want to select the version of the JS library used, or want to serve it from
     the local 'static' resources, add a line to your settings.py like so::
 
         SELECT2_JS_LIB_FILE = 'mylocaljslibs/select2.min.js'
@@ -61,7 +61,7 @@ class Select2Conf(AppConf):
     """
     The URI for the Select2 CSS file. By default this points to the Cloudflare CDN.
 
-    If you want to select the version of the library used, or want to serve it from 
+    If you want to select the version of the library used, or want to serve it from
     the local 'static' resources, add a line to your settings.py like so::
 
         SELECT2_CSS_LIB_FILE = 'assets/css/select2-4.0.1.css.js'

--- a/django_select2/conf.py
+++ b/django_select2/conf.py
@@ -66,14 +66,14 @@ class Select2Conf(AppConf):
 
         SELECT2_CSS_LIB_FILE = 'assets/css/select2-4.0.1.css.js'
     """
-    JS_MEDIA = None
+    MEDIA_JS = (getattr(settings, 'SELECT2_JS_LIB_FILE', JS_LIB_FILE), 'django_select2/django_select2.js')
     """
     The configuration provided for ``js`` to the ``media`` attibute of the ``Select2Mixin``.
 
     .. note:: If you need to change this, we assume you have read the code and know
         what you are doing.
     """
-    CSS_MEDIA = None
+    MEDIA_CSS = {'screen': (getattr(settings, 'SELECT2_CSS_LIB_FILE', CSS_LIB_FILE), )}
     """
     The configuration provided for ``css`` to the ``media`` attibute of the ``Select2Mixin``.
 

--- a/django_select2/conf.py
+++ b/django_select2/conf.py
@@ -48,5 +48,38 @@ class Select2Conf(AppConf):
     It has set `select2_` as a default value, which you can change if needed.
     """
 
+    JS_LIB_FILE = '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js'
+    """
+    The URI for the Select2 JS file. By default this points to the Cloudflare CDN.
+
+    If you want to select the version of the JS library used, or want to serve it from 
+    the local 'static' resources, add a line to your settings.py like so::
+
+        SELECT2_JS_LIB_FILE = 'mylocaljslibs/select2.min.js'
+    """
+    CSS_LIB_FILE = '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css'
+    """
+    The URI for the Select2 CSS file. By default this points to the Cloudflare CDN.
+
+    If you want to select the version of the library used, or want to serve it from 
+    the local 'static' resources, add a line to your settings.py like so::
+
+        SELECT2_CSS_LIB_FILE = 'assets/css/select2-4.0.1.css.js'
+    """
+    JS_MEDIA = (getattr(settings, 'SELECT2_JS_LIB_FILE', JS_LIB_FILE), 'django_select2/django_select2.js')
+    """
+    The configuration provided for ``js`` to the ``media`` attibute of the ``Select2Mixin``.
+
+    .. note:: If you need to change this, we assume you have read the code and know
+        what you are doing.
+    """
+    CSS_MEDIA = {'screen': (getattr(settings, 'SELECT2_CSS_LIB_FILE', CSS_LIB_FILE), )}
+    """
+    The configuration provided for ``css`` to the ``media`` attibute of the ``Select2Mixin``.
+
+    .. note:: If you need to change this, we assume you have read the code and know
+        what you are doing.
+    """
+
     class Meta:
         prefix = 'SELECT2'

--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -100,14 +100,9 @@ class Select2Mixin(object):
         .. Note:: For more information visit
             https://docs.djangoproject.com/en/1.8/topics/forms/media/#media-as-a-dynamic-property
         """
-        js_media = settings.SELECT2_JS_MEDIA if settings.SELECT2_JS_MEDIA is not None else (
-            settings.SELECT2_JS_LIB_FILE, 'django_select2/django_select2.js')
-        css_media = settings.SELECT2_CSS_MEDIA if settings.SELECT2_CSS_MEDIA is not None else {
-            'screen': (settings.SELECT2_CSS_LIB_FILE,)}
-
         return forms.Media(
-            js=js_media,
-            css=css_media
+            js=settings.SELECT2_MEDIA_JS,
+            css=settings.SELECT2_MEDIA_CSS
         )
 
     media = property(_get_media)

--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -101,9 +101,8 @@ class Select2Mixin(object):
             https://docs.djangoproject.com/en/1.8/topics/forms/media/#media-as-a-dynamic-property
         """
         return forms.Media(
-            js=('//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js',
-                'django_select2/django_select2.js'),
-            css={'screen': ('//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css',)}
+            js=settings.SELECT2_JS_MEDIA,
+            css=settings.SELECT2_CSS_MEDIA
         )
 
     media = property(_get_media)

--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -100,9 +100,14 @@ class Select2Mixin(object):
         .. Note:: For more information visit
             https://docs.djangoproject.com/en/1.8/topics/forms/media/#media-as-a-dynamic-property
         """
+        js_media = settings.SELECT2_JS_MEDIA if settings.SELECT2_JS_MEDIA is not None else (
+            settings.SELECT2_JS_LIB_FILE, 'django_select2/django_select2.js')
+        css_media = settings.SELECT2_CSS_MEDIA if settings.SELECT2_CSS_MEDIA is not None else {
+            'screen': (settings.SELECT2_CSS_LIB_FILE,)}
+
         return forms.Media(
-            js=settings.SELECT2_JS_MEDIA,
-            css=settings.SELECT2_CSS_MEDIA
+            js=js_media,
+            css=css_media
         )
 
     media = property(_get_media)

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -8,7 +8,7 @@ import pytest
 from django.core import signing
 from django.core.urlresolvers import reverse
 from django.db.models import QuerySet
-from django.test import TestCase
+from django.test import override_settings
 from django.utils.encoding import force_text
 from selenium.common.exceptions import NoSuchElementException
 from six import text_type
@@ -83,8 +83,6 @@ class TestSelect2Mixin(object):
         widget = HeavySelect2Widget(data_url='/foo/bar')
         assert widget.get_url() == '/foo/bar'
 
-
-class TestSelect2MixinSettings(TestCase):
     def test_default_media_is_cloudflare_4_0_0_version(self):
         sut = Select2Widget()
         result = sut.media.render()
@@ -92,34 +90,34 @@ class TestSelect2MixinSettings(TestCase):
         assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css' in result
         assert 'django_select2/django_select2.js' in result
 
+    @override_settings(SELECT2_JS_LIB_FILE='alternate_select2_lib_file')
     def test_js_media_contains_alternate_file_if_supplied_through_settings(self):
         sut = Select2Widget()
-        with self.settings(SELECT2_JS_LIB_FILE='alternate_select2_lib_file', SELECT_JS_MEDIA=[]):
-            result = sut.media.render()
-            assert 'alternate_select2_lib_file' in result
-            assert 'django_select2/django_select2.js' in result
+        result = sut.media.render()
+        assert 'alternate_select2_lib_file' in result
+        assert 'django_select2/django_select2.js' in result
 
+    @override_settings(SELECT2_CSS_LIB_FILE='alternate_select2_lib_file')
     def test_css_media_contains_alternate_file_if_supplied_through_settings(self):
         sut = Select2Widget()
-        with self.settings(SELECT2_CSS_LIB_FILE='alternate_select2_lib_file'):
-            result = sut.media.render()
-            assert 'alternate_select2_lib_file' in result
+        result = sut.media.render()
+        assert 'alternate_select2_lib_file' in result
 
+    @override_settings(SELECT2_MEDIA_JS=[])
     def test_js_media_entirely_replaced_if_supplied_through_settings(self):
         sut = Select2Widget()
-        with self.settings(SELECT2_JS_MEDIA=[]):
-            result = sut.media.render()
-            assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js' not in result
-            assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css' in result
-            assert 'django_select2/django_select2.js' not in result
+        result = sut.media.render()
+        assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js' not in result
+        assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css' in result
+        assert 'django_select2/django_select2.js' not in result
 
+    @override_settings(SELECT2_MEDIA_CSS={})
     def test_css_media_entirely_replaced_if_supplied_through_settings(self):
         sut = Select2Widget()
-        with self.settings(SELECT2_CSS_MEDIA={}):
-            result = sut.media.render()
-            assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js' in result
-            assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css' not in result
-            assert 'django_select2/django_select2.js' in result
+        result = sut.media.render()
+        assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js' in result
+        assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css' not in result
+        assert 'django_select2/django_select2.js' in result
 
 
 class TestHeavySelect2Mixin(TestSelect2Mixin):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -9,7 +9,7 @@ from django.core import signing
 from django.core.urlresolvers import reverse
 from django.db.models import QuerySet
 from django.utils.encoding import force_text
-from django.test import modify_settings
+from django.test import TestCase
 from selenium.common.exceptions import NoSuchElementException
 from six import text_type
 
@@ -90,34 +90,36 @@ class TestSelect2Mixin(object):
         assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css' in result
         assert 'django_select2/django_select2.js' in result
 
-    @modify_settings(SELECT2_JS_LIB_FILE='alternate_select2_lib_file')
+
+class TestSelect2MixinSettings(TestCase):
     def test_js_media_contains_alternate_file_if_supplied_through_settings(self):
-        sut = self.widget_cls()
-        result = sut.media.render()
-        assert 'alternate_select2_lib_file' in result
-        assert 'django_select2/django_select2.js' in result
+        sut = Select2Widget()
+        with self.settings(SELECT2_JS_LIB_FILE='alternate_select2_lib_file', SELECT_JS_MEDIA=[]):
+            result = sut.media.render()
+            assert 'alternate_select2_lib_file' in result
+            assert 'django_select2/django_select2.js' in result
 
-    @modify_settings(SELECT2_CSS_LIB_FILE='alternate_select2_lib_file')
     def test_css_media_contains_alternate_file_if_supplied_through_settings(self):
-        sut = self.widget_cls()
-        result = sut.media.render()
-        assert 'alternate_select2_lib_file' in result
+        sut = Select2Widget()
+        with self.settings(SELECT2_CSS_LIB_FILE='alternate_select2_lib_file'):
+            result = sut.media.render()
+            assert 'alternate_select2_lib_file' in result
 
-    @modify_settings(SELECT2_JS_MEDIA=(None,))
     def test_js_media_entirely_replaced_if_supplied_through_settings(self):
-        sut = self.widget_cls()
-        result = sut.media.render()
-        assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js' not in result
-        assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css' in result
-        assert 'django_select2/django_select2.js' not in result
+        sut = Select2Widget()
+        with self.settings(SELECT2_JS_MEDIA=[]):
+            result = sut.media.render()
+            assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js' not in result
+            assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css' in result
+            assert 'django_select2/django_select2.js' not in result
 
-    @modify_settings(SELECT2_CSS_LIB_FILE={})
     def test_css_media_entirely_replaced_if_supplied_through_settings(self):
-        sut = self.widget_cls()
-        result = sut.media.render()
-        assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js' in result
-        assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css' not in result
-        assert 'django_select2/django_select2.js' in result
+        sut = Select2Widget()
+        with self.settings(SELECT2_CSS_MEDIA={}):
+            result = sut.media.render()
+            assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js' in result
+            assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css' not in result
+            assert 'django_select2/django_select2.js' in result
 
 
 class TestHeavySelect2Mixin(TestSelect2Mixin):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -8,7 +8,6 @@ import pytest
 from django.core import signing
 from django.core.urlresolvers import reverse
 from django.db.models import QuerySet
-from django.test import override_settings
 from django.utils.encoding import force_text
 from selenium.common.exceptions import NoSuchElementException
 from six import text_type

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -87,15 +87,15 @@ class TestSelect2Mixin(object):
         sut = self.widget_cls()
         result = sut.media.render()
         assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js' in result
-        assert 'django_select2/django_select.js' in result
         assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css' in result
+        assert 'django_select2/django_select2.js' in result
 
     @modify_settings(SELECT2_JS_LIB_FILE='alternate_select2_lib_file')
     def test_js_media_contains_alternate_file_if_supplied_through_settings(self):
         sut = self.widget_cls()
         result = sut.media.render()
         assert 'alternate_select2_lib_file' in result
-        assert 'django_select2/django_select.js' in result
+        assert 'django_select2/django_select2.js' in result
 
     @modify_settings(SELECT2_CSS_LIB_FILE='alternate_select2_lib_file')
     def test_css_media_contains_alternate_file_if_supplied_through_settings(self):
@@ -108,16 +108,16 @@ class TestSelect2Mixin(object):
         sut = self.widget_cls()
         result = sut.media.render()
         assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js' not in result
-        assert 'django_select2/django_select.js' not in result
         assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css' in result
+        assert 'django_select2/django_select2.js' not in result
 
     @modify_settings(SELECT2_CSS_LIB_FILE={})
     def test_css_media_entirely_replaced_if_supplied_through_settings(self):
         sut = self.widget_cls()
         result = sut.media.render()
         assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js' in result
-        assert 'django_select2/django_select.js' in result
         assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css' not in result
+        assert 'django_select2/django_select2.js' in result
 
 
 class TestHeavySelect2Mixin(TestSelect2Mixin):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -9,6 +9,7 @@ from django.core import signing
 from django.core.urlresolvers import reverse
 from django.db.models import QuerySet
 from django.utils.encoding import force_text
+from django.test import modify_settings
 from selenium.common.exceptions import NoSuchElementException
 from six import text_type
 
@@ -82,6 +83,32 @@ class TestSelect2Mixin(object):
         widget = HeavySelect2Widget(data_url='/foo/bar')
         assert widget.get_url() == '/foo/bar'
 
+    def test_default_media_is_cloudflare_4_0_0_version(self):
+        sut = self.widget_cls()
+        assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js' in sut.media.js
+        assert 'django_select2/django_select.js' in sut.media.js
+        assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css' in sut.media.css['screen']
+
+    @modify_settings(SELECT2_JS_LIB_FILE='alternate_select2_lib_file')
+    def test_js_media_contains_alternate_file_if_supplied_through_settings(self):
+        sut = self.widget_cls()
+        assert 'alternate_select2_lib_file' in sut.media.js
+        assert 'django_select2/django_select.js' in sut.media.js
+
+    @modify_settings(SELECT2_CSS_LIB_FILE='alternate_select2_lib_file')
+    def test_css_media_contains_alternate_file_if_supplied_through_settings(self):
+        sut = self.widget_cls()
+        assert 'alternate_select2_lib_file' in sut.media.css['screen']
+
+    @modify_settings(SELECT2_JS_MEDIA=(None,))
+    def test_js_media_entirely_replaced_if_supplied_through_settings(self):
+        sut = self.widget_cls()
+        assert (None, ) == sut.media.js
+
+    @modify_settings(SELECT2_CSS_LIB_FILE={})
+    def test_css_media_entirely_replaced_if_supplied_through_settings(self):
+        sut = self.widget_cls()
+        assert {} == sut.media.css
 
 class TestHeavySelect2Mixin(TestSelect2Mixin):
     url = reverse('heavy_select2_widget')

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -85,30 +85,40 @@ class TestSelect2Mixin(object):
 
     def test_default_media_is_cloudflare_4_0_0_version(self):
         sut = self.widget_cls()
-        assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js' in sut.media.js
-        assert 'django_select2/django_select.js' in sut.media.js
-        assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css' in sut.media.css['screen']
+        result = sut.media.render()
+        assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js' in result
+        assert 'django_select2/django_select.js' in result
+        assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css' in result
 
     @modify_settings(SELECT2_JS_LIB_FILE='alternate_select2_lib_file')
     def test_js_media_contains_alternate_file_if_supplied_through_settings(self):
         sut = self.widget_cls()
-        assert 'alternate_select2_lib_file' in sut.media.js
-        assert 'django_select2/django_select.js' in sut.media.js
+        result = sut.media.render()
+        assert 'alternate_select2_lib_file' in result
+        assert 'django_select2/django_select.js' in result
 
     @modify_settings(SELECT2_CSS_LIB_FILE='alternate_select2_lib_file')
     def test_css_media_contains_alternate_file_if_supplied_through_settings(self):
         sut = self.widget_cls()
-        assert 'alternate_select2_lib_file' in sut.media.css['screen']
+        result = sut.media.render()
+        assert 'alternate_select2_lib_file' in result
 
     @modify_settings(SELECT2_JS_MEDIA=(None,))
     def test_js_media_entirely_replaced_if_supplied_through_settings(self):
         sut = self.widget_cls()
-        assert (None, ) == sut.media.js
+        result = sut.media.render()
+        assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js' not in result
+        assert 'django_select2/django_select.js' not in result
+        assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css' in result
 
     @modify_settings(SELECT2_CSS_LIB_FILE={})
     def test_css_media_entirely_replaced_if_supplied_through_settings(self):
         sut = self.widget_cls()
-        assert {} == sut.media.css
+        result = sut.media.render()
+        assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js' in result
+        assert 'django_select2/django_select.js' in result
+        assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css' not in result
+
 
 class TestHeavySelect2Mixin(TestSelect2Mixin):
     url = reverse('heavy_select2_widget')

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -90,35 +90,6 @@ class TestSelect2Mixin(object):
         assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css' in result
         assert 'django_select2/django_select2.js' in result
 
-    @override_settings(SELECT2_JS_LIB_FILE='alternate_select2_lib_file')
-    def test_js_media_contains_alternate_file_if_supplied_through_settings(self):
-        sut = Select2Widget()
-        result = sut.media.render()
-        assert 'alternate_select2_lib_file' in result
-        assert 'django_select2/django_select2.js' in result
-
-    @override_settings(SELECT2_CSS_LIB_FILE='alternate_select2_lib_file')
-    def test_css_media_contains_alternate_file_if_supplied_through_settings(self):
-        sut = Select2Widget()
-        result = sut.media.render()
-        assert 'alternate_select2_lib_file' in result
-
-    @override_settings(SELECT2_MEDIA_JS=[])
-    def test_js_media_entirely_replaced_if_supplied_through_settings(self):
-        sut = Select2Widget()
-        result = sut.media.render()
-        assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js' not in result
-        assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css' in result
-        assert 'django_select2/django_select2.js' not in result
-
-    @override_settings(SELECT2_MEDIA_CSS={})
-    def test_css_media_entirely_replaced_if_supplied_through_settings(self):
-        sut = Select2Widget()
-        result = sut.media.render()
-        assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js' in result
-        assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css' not in result
-        assert 'django_select2/django_select2.js' in result
-
 
 class TestHeavySelect2Mixin(TestSelect2Mixin):
     url = reverse('heavy_select2_widget')

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -83,15 +83,15 @@ class TestSelect2Mixin(object):
         widget = HeavySelect2Widget(data_url='/foo/bar')
         assert widget.get_url() == '/foo/bar'
 
+
+class TestSelect2MixinSettings(TestCase):
     def test_default_media_is_cloudflare_4_0_0_version(self):
-        sut = self.widget_cls()
+        sut = Select2Widget()
         result = sut.media.render()
         assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/js/select2.min.js' in result
         assert '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.min.css' in result
         assert 'django_select2/django_select2.js' in result
 
-
-class TestSelect2MixinSettings(TestCase):
     def test_js_media_contains_alternate_file_if_supplied_through_settings(self):
         sut = Select2Widget()
         with self.settings(SELECT2_JS_LIB_FILE='alternate_select2_lib_file', SELECT_JS_MEDIA=[]):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -8,8 +8,8 @@ import pytest
 from django.core import signing
 from django.core.urlresolvers import reverse
 from django.db.models import QuerySet
-from django.utils.encoding import force_text
 from django.test import TestCase
+from django.utils.encoding import force_text
 from selenium.common.exceptions import NoSuchElementException
 from six import text_type
 


### PR DESCRIPTION
These changes introduce additional (optional) configuration parameters.
The parameters allow the user of the library to select different JS/CSS
libraries from the ones shipped. In particular, this allows serving from
the local server and/or in private-network-only environments (i.e. if you can't hit the CDN).

Sorry about the number of commits. I couldn't for the life of me get the tests to execute locally.