### PR TITLE
Include cPickle.PicklingError

### DIFF
--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -51,7 +51,7 @@ from __future__ import absolute_import, unicode_literals
 from functools import reduce
 from itertools import chain
 from pickle import PicklingError
-from cPickle import PicklingError as cPicklingError
+from six.moves.cPickle import PicklingError as cPicklingError
 
 from django import forms
 from django.core import signing

--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -51,7 +51,6 @@ from __future__ import absolute_import, unicode_literals
 from functools import reduce
 from itertools import chain
 from pickle import PicklingError
-from six.moves.cPickle import PicklingError as cPicklingError
 
 from django import forms
 from django.core import signing
@@ -59,6 +58,8 @@ from django.core.urlresolvers import reverse
 from django.db.models import Q
 from django.forms.models import ModelChoiceIterator
 from django.utils.encoding import force_text
+
+from six.moves.cPickle import PicklingError as cPicklingError
 
 from .cache import cache
 from .conf import settings

--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -51,6 +51,7 @@ from __future__ import absolute_import, unicode_literals
 from functools import reduce
 from itertools import chain
 from pickle import PicklingError
+from cPickle import PicklingError as cPicklingError
 
 from django import forms
 from django.core import signing
@@ -233,7 +234,7 @@ class HeavySelect2Mixin(object):
                 'widget': self,
                 'url': self.get_url(),
             })
-        except (PicklingError, AttributeError):
+        except (PicklingError, cPicklingError, AttributeError):
             msg = "You need to overwrite \"set_to_cache\" or ensure that %s is serialisable."
             raise NotImplementedError(msg % self.__class__.__name__)
 


### PR DESCRIPTION
`PickleError` could be from `cPickle` module so it has to be included.

Also one comment on this topic: definition of items in `widget_dict` in base class and handling `PicklingError`s with `NotImplementedError` might not be good approach. This `widget_dict` definition can force user to create its widget and override `set_to_cache˙ just to avoid this error. 

Methods in the base classes (mixins) should implement only necessary actions and in this case `widget_dict` definition should be up to the derived class since it just might not need `widget_dict` at all i.e. in case when the view handling ajax is not generic, and that could be the regular use case.