### PR TITLE
Changed Token Separators

### DIFF
--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -118,7 +118,7 @@ class Select2TagMixin(object):
         """Add select2's tag attributes."""
         self.attrs.setdefault('data-minimum-input-length', 1)
         self.attrs.setdefault('data-tags', 'true')
-        self.attrs.setdefault('data-token-separators', [",", " "])
+        self.attrs.setdefault('data-token-separators', '[",", " "]')
         return super(Select2TagMixin, self).build_attrs(extra_attrs, **kwargs)
 
 


### PR DESCRIPTION
When Django was parsing the separator attribute, it was coming with 'u' char from Unicode type.
It was causing that whenever we press 'u' key, it was behaving like pressing ',' or 'SPACE'.
So the trick was to put the value in a string. Solved #238 issue!