### PR TITLE
New feature - Choosing a dependent form field to narrow queryset

### DIFF
--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -48,10 +48,10 @@ Light widgets are normally named, i.e. there is no
 """
 from __future__ import absolute_import, unicode_literals
 
+import operator
 from functools import reduce
 from itertools import chain
 from pickle import PicklingError
-import operator
 
 from django import forms
 from django.core import signing

--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -211,8 +211,6 @@ class HeavySelect2Mixin(object):
         attrs.setdefault('data-ajax--cache', "true")
         attrs.setdefault('data-ajax--type', "GET")
         attrs.setdefault('data-minimum-input-length', 2)
-        if self.depends_form_id:
-            attrs.setdefault('data-depends-id', self.depends_form_id)
 
         attrs['class'] += ' django-select2-heavy'
         return attrs

--- a/django_select2/static/django_select2/django_select2.js
+++ b/django_select2/static/django_select2/django_select2.js
@@ -1,4 +1,12 @@
 (function ($) {
+    var depends = function($element){
+        var data = $('#'+$element.data('depends-id')).serializeArray();
+        r = Object.keys(data).reduce(function(res, v) {
+            return res.concat(data[v].value);
+        }, []);
+        if(r.length !== 0) return r.join('|');
+        return undefined;
+    }
 
     var init = function ($element, options) {
         $element.select2(options);
@@ -11,6 +19,7 @@
                     return {
                         term: params.term,
                         page: params.page,
+                        depends: depends($element),
                         field_id: $element.data('field_id')
                     };
                 },

--- a/django_select2/views.py
+++ b/django_select2/views.py
@@ -37,6 +37,7 @@ class AutoResponseView(BaseListView):
         """
         self.widget = self.get_widget_or_404()
         self.term = kwargs.get('term', request.GET.get('term', ''))
+        self.depends_values = kwargs.get('depends', request.GET.get('depends', None))
         self.object_list = self.get_queryset()
         context = self.get_context_data()
         return JsonResponse({
@@ -52,7 +53,7 @@ class AutoResponseView(BaseListView):
 
     def get_queryset(self):
         """Get QuerySet from cached widget."""
-        return self.widget.filter_queryset(self.term, self.queryset)
+        return self.widget.filter_queryset(self.term, self.queryset, self.depends_values)
 
     def get_paginate_by(self, queryset):
         """Paginate response by size of widget's `max_results` parameter."""


### PR DESCRIPTION
Example of use :
```
class FiltersForm(forms.Form):
    departments = forms.ModelMultipleChoiceField(
        widget=Select2MultipleWidget(
            attrs={
                'data-placeholder': _(u"Tous les départements"),
                'data-theme': 'search',
                'id': 'AN_UNIQUE_ID',
            }
        ),
        queryset=Department.objects.all(),
        required=False,
    )
    city = forms.ModelChoiceField(
        widget=ModelSelect2Widget(
            attrs={
                'data-placeholder': _(u"Toutes les villes"),
                'data-theme': 'search',
            },
            model=City,
            search_fields=['name__istartswith', 'zip_code__istartswith', ],
            depends_form_id='AN_UNIQUE_ID',
            queryset_extra='department',
        ),
        required=False,
        queryset=City.objects.all(),
    )
```