### PR TITLE
Functionality for dependent selects

### DIFF
--- a/django_select2/static/django_select2/django_select2.js
+++ b/django_select2/static/django_select2/django_select2.js
@@ -7,11 +7,20 @@
     var settings = $.extend({
       ajax: {
         data: function (params) {
-          return {
+          var res = {
             term: params.term,
             page: params.page,
             field_id: $element.data('field_id')
           }
+
+          var parentClasses = $element.data('chain-parent')
+          if (parentClasses) {
+            parentClasses = parentClasses.trim().split(/\s+/)
+            $.each(parentClasses, function (i, parentClass) {
+              res[parentClass] = $('.' + parentClass).val()
+            })
+          }
+          return res
         },
         processResults: function (data, page) {
           return {

--- a/django_select2/static/django_select2/django_select2.js
+++ b/django_select2/static/django_select2/django_select2.js
@@ -7,20 +7,20 @@
     var settings = $.extend({
       ajax: {
         data: function (params) {
-          var res = {
+          var result = {
             term: params.term,
             page: params.page,
             field_id: $element.data('field_id')
           }
 
-          var parentClasses = $element.data('chain-parent')
+          var parentClasses = $element.data('select2-parents')
           if (parentClasses) {
             parentClasses = parentClasses.trim().split(/\s+/)
             $.each(parentClasses, function (i, parentClass) {
-              res[parentClass] = $('.' + parentClass).val()
+              result[parentClass] = $('.' + parentClass).val()
             })
           }
-          return res
+          return result
         },
         processResults: function (data, page) {
           return {

--- a/docs/extra.rst
+++ b/docs/extra.rst
@@ -1,0 +1,168 @@
+Extra
+=====
+
+Chained select2
+---------------
+
+Suppose you have an address form where user should choose a Country and a City.
+The problem is different countries have different cities.
+So we need to show to the user only cities available in the selected country.
+
+Models
+``````
+
+Here are our two models:
+
+.. code-block:: python
+
+    class Country(models.Model):
+        name = models.CharField(max_length=255)
+
+
+    class City(models.Model):
+        name = models.CharField(max_length=255)
+        country = models.ForeignKey('Country')
+
+
+Customizing a Form
+``````````````````
+
+Lets link two widgets via *country_selector* (it's an arbitrary name for CSS class).
+
+.. code-block:: python
+    :emphasize-lines: 7,15,18
+
+    class AddressForm(forms.Form):
+        country = forms.ModelChoiceField(
+            queryset=Country.objects.all(),
+            label=u"Country",
+            widget=ModelSelect2Widget(
+                search_fields=['name__icontains'],
+                attrs={
+                    'class': 'country_selector'
+                }
+            )
+        )
+
+        city = forms.ModelChoiceField(
+            queryset=City.objects.all(),
+            label=u"City",
+            widget=ModelSelect2Widget(
+                data_url='/cities_by_country/',
+                search_fields=['name__icontains'],
+                attrs={
+                    'data-chain-parent': 'country_selector'
+                }
+            )
+        )
+
+
+Registering a view
+``````````````````
+
+Add new route to *urls.py* for retrieving filtered cities:
+
+.. code-block:: python
+
+    from django.conf.urls import patterns, url
+    urlpatterns = patterns(
+        # ...
+        url('^cities_by_country/$', 'cities_by_country', name='cities_by_country'),
+    )
+
+Creating a view
+```````````````
+
+Add a method to *views.py*:
+
+.. code-block:: python
+
+    def cities_by_country(request):
+        filter_query = Q()
+        if request.GET.get('country_selector'):
+            filter_query &= Q(country__in=request.GET.getlist('country_selector'))
+
+        result = {
+            'results': [
+                {
+                    'text': instance.name,
+                    'id': instance.pk
+                } for instance in City.objects.filter(filter_query).distinct().order_by('name')
+            ],
+            'more': True
+        }
+
+        return HttpResponse(json.dumps(result), content_type='application/json')
+
+
+Interdependent select2
+----------------------
+
+Also you may want not to restrict user to which field should be selected first.
+Instead you want to suggest to the user options for any select2 depending of his selection in another one.
+
+Customize the form in a manner:
+
+.. code-block:: python
+    :emphasize-lines: 5,8-9,17,20-21
+
+    class AddressForm(forms.Form):
+        country = forms.ModelChoiceField(
+            label=u"Country",
+            widget=ModelSelect2Widget(
+                data_url='/countries_by_city/',
+                search_fields=['name__icontains'],
+                attrs={
+                    'class': 'country_selector',
+                    'data-chain-parent': 'city_selector'
+                }
+            )
+        )
+
+        city = forms.ModelChoiceField(
+            label=u"City",
+            widget=ModelSelect2Widget(
+                data_url='/cities_by_country/',
+                search_fields=['name__icontains'],
+                attrs={
+                    'class': 'city_selector',
+                    'data-chain-parent': 'country_selector'
+                }
+            )
+        )
+
+
+Multi-dependent select2
+-----------------------
+
+Furthermore you may want to filter options on two or more select2 selections (some code is dropped for clarity):
+
+.. code-block:: python
+    :emphasize-lines: 22
+
+    class SomeForm(forms.Form):
+        field1 = forms.ModelChoiceField(
+            widget=ModelSelect2Widget(
+                attrs={
+                    'class': 'field1_selector'
+                }
+            )
+        )
+
+        field2 = forms.ModelChoiceField(
+            widget=ModelSelect2Widget(
+                attrs={
+                    'class': 'field2_selector'
+                }
+            )
+        )
+
+        field3 = forms.ModelChoiceField(
+            widget=ModelSelect2Widget(
+                data_url='/field3_by_field1_and_field2/',
+                attrs={
+                    'data-chain-parent': 'field1_selector field2_selector'
+                }
+            )
+        )
+

--- a/docs/extra.rst
+++ b/docs/extra.rst
@@ -51,7 +51,7 @@ Lets link two widgets via *country_selector* (it's an arbitrary name for CSS cla
                 data_url='/cities_by_country/',
                 search_fields=['name__icontains'],
                 attrs={
-                    'data-chain-parent': 'country_selector'
+                    'data-select2-parents': 'country_selector'
                 }
             )
         )
@@ -114,7 +114,7 @@ Customize the form in a manner:
                 search_fields=['name__icontains'],
                 attrs={
                     'class': 'country_selector',
-                    'data-chain-parent': 'city_selector'
+                    'data-select2-parents': 'city_selector'
                 }
             )
         )
@@ -126,7 +126,7 @@ Customize the form in a manner:
                 search_fields=['name__icontains'],
                 attrs={
                     'class': 'city_selector',
-                    'data-chain-parent': 'country_selector'
+                    'data-select2-parents': 'country_selector'
                 }
             )
         )
@@ -161,7 +161,7 @@ Furthermore you may want to filter options on two or more select2 selections (so
             widget=ModelSelect2Widget(
                 data_url='/field3_by_field1_and_field2/',
                 attrs={
-                    'data-chain-parent': 'field1_selector field2_selector'
+                    'data-select2-parents': 'field1_selector field2_selector'
                 }
             )
         )

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Contents:
 
    get_started
    django_select2
+   extra
 
 Indices and tables
 ==================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,11 @@ def random_string(n):
     )
 
 
+def random_name(n):
+    words = ''.join(random.choice(string.ascii_lowercase + ' ') for _ in range(n)).strip().split(' ')
+    return '-'.join([x.capitalize() for x in words])
+
+
 @pytest.yield_fixture(scope='session', params=sorted(browsers.keys()))
 def driver(request):
     if 'DISPLAY' not in os.environ:
@@ -57,4 +62,20 @@ def artists(db):
     from .testapp.models import Artist
     return Artist.objects.bulk_create(
         [Artist(pk=pk, title=random_string(50)) for pk in range(100)]
+    )
+
+
+@pytest.fixture
+def countries(db):
+    from .testapp.models import Country
+    return Country.objects.bulk_create(
+        [Country(pk=pk, name=random_name(random.randint(10, 20))) for pk in range(10)]
+    )
+
+
+@pytest.fixture
+def cities(db, countries):
+    from .testapp.models import City
+    return City.objects.bulk_create(
+        [City(pk=pk, name=random_name(random.randint(5, 15)), country=random.choice(countries)) for pk in range(100)]
     )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -98,3 +98,35 @@ class TestAutoResponseView(object):
         url = reverse('django_select2-json')
         response = client.get(url, {'field_id': field_id, 'term': artist.title})
         assert response.status_code == 404
+
+    def test_cities_by_country_url_returns_filtered_list_of_cities(self, client, countries, cities):
+        assert len(countries) == 10
+        assert len(cities) == 100
+
+        url = reverse('cities_by_country')
+        request_count = 0
+        for country in countries:
+            if country.city_set.count() > 0:
+                response = client.get(url, {'country_selector': country.pk})
+                request_count += 1
+                assert response.status_code == 200
+
+                data = json.loads(response.content.decode('utf-8'))
+                assert data['results']
+                assert len(data['results']) == country.city_set.count()
+        else:
+            assert request_count > 0, "At least one request to this URL should be done."
+
+    def test_cities_by_country_url_returns_all_cities(self, client, countries, cities):
+        # _when_called_without_country_selector
+        assert len(countries) == 10
+        assert len(cities) == 100
+
+        url = reverse('cities_by_country')
+
+        response = client.get(url)
+        assert response.status_code == 200
+
+        data = json.loads(response.content.decode('utf-8'))
+        assert data['results']
+        assert len(data['results']) == len(cities)

--- a/tests/testapp/forms.py
+++ b/tests/testapp/forms.py
@@ -10,7 +10,7 @@ from django_select2.forms import (
     Select2Widget
 )
 from tests.testapp import models
-from tests.testapp.models import Album
+from tests.testapp.models import Album, City, Country
 
 
 class TitleSearchFieldMixin(object):
@@ -174,3 +174,28 @@ class ModelSelect2TagWidgetForm(forms.ModelForm):
         widgets = {
             'genres': GenreSelect2TagWidget
         }
+
+
+class AddressChainedSelect2WidgetForm(forms.Form):
+    country = forms.ModelChoiceField(
+        queryset=Country.objects.all(),
+        label=u"Country",
+        widget=ModelSelect2Widget(
+            search_fields=['name__icontains'],
+            attrs={
+                'class': 'country_selector'
+            }
+        )
+    )
+
+    city = forms.ModelChoiceField(
+        queryset=City.objects.all(),
+        label=u"City",
+        widget=ModelSelect2Widget(
+            data_url='/cities_by_country/',
+            search_fields=['name__icontains'],
+            attrs={
+                'data-chain-parent': 'country_selector'
+            }
+        )
+    )

--- a/tests/testapp/forms.py
+++ b/tests/testapp/forms.py
@@ -195,7 +195,7 @@ class AddressChainedSelect2WidgetForm(forms.Form):
             data_url='/cities_by_country/',
             search_fields=['name__icontains'],
             attrs={
-                'data-chain-parent': 'country_selector'
+                'data-select2-parents': 'country_selector'
             }
         )
     )

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -32,3 +32,20 @@ class Album(models.Model):
 
     def __str__(self):
         return self.title
+
+
+@python_2_unicode_compatible
+class Country(models.Model):
+    name = models.CharField(max_length=255)
+
+    def __str__(self):
+        return self.name
+
+
+@python_2_unicode_compatible
+class City(models.Model):
+    name = models.CharField(max_length=255)
+    country = models.ForeignKey('Country')
+
+    def __str__(self):
+        return self.name

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -4,10 +4,13 @@ from __future__ import absolute_import, unicode_literals
 from django.conf.urls import include, url
 
 from .forms import (
-    AlbumModelSelect2WidgetForm, HeavySelect2MultipleWidgetForm,
-    HeavySelect2WidgetForm, ModelSelect2TagWidgetForm, Select2WidgetForm
+    AddressChainedSelect2WidgetForm, AlbumModelSelect2WidgetForm,
+    HeavySelect2MultipleWidgetForm, HeavySelect2WidgetForm,
+    ModelSelect2TagWidgetForm, Select2WidgetForm
 )
-from .views import TemplateFormView, heavy_data_1, heavy_data_2
+from .views import (
+    TemplateFormView, cities_by_country, heavy_data_1, heavy_data_2
+)
 
 urlpatterns = [
     url(r'^select2_widget/$',
@@ -26,8 +29,14 @@ urlpatterns = [
         TemplateFormView.as_view(form_class=ModelSelect2TagWidgetForm),
         name='model_select2_tag_widget'),
 
+    url(r'^model_chained_select2_widget/$',
+        TemplateFormView.as_view(form_class=AddressChainedSelect2WidgetForm),
+        name='model_chained_select2_widget'),
+
     url(r'^heavy_data_1/$', heavy_data_1, name='heavy_data_1'),
     url(r'^heavy_data_2/$', heavy_data_2, name='heavy_data_2'),
+
+    url('^cities_by_country/$', cities_by_country, name='cities_by_country'),
 
     url(r'^select2/', include('django_select2.urls')),
 ]

--- a/tests/testapp/views.py
+++ b/tests/testapp/views.py
@@ -3,8 +3,11 @@ from __future__ import unicode_literals
 
 import json
 
+from django.db.models import Q
 from django.http import HttpResponse
 from django.views.generic import FormView
+
+from tests.testapp.models import City
 
 
 class TemplateFormView(FormView):
@@ -25,3 +28,21 @@ def heavy_data_2(request):
     numbers = filter(lambda num: term.lower() in num.lower(), numbers)
     results = [{'id': index, 'text': value} for (index, value) in enumerate(numbers)]
     return HttpResponse(json.dumps({'err': 'nil', 'results': results}), content_type='application/json')
+
+
+def cities_by_country(request):
+    filter_query = Q()
+    if request.GET.get('country_selector'):
+        filter_query &= Q(country__in=request.GET.getlist('country_selector'))
+
+    result = {
+        'results': [
+            {
+                'text': instance.name,
+                'id': instance.pk
+            } for instance in City.objects.filter(filter_query).distinct().order_by('name')
+        ],
+        'more': False
+    }
+
+    return HttpResponse(json.dumps(result), content_type='application/json')


### PR DESCRIPTION
What if one control should list options depending on user input from another control?

All we need is:
- to create custom view for options, which takes additional parameters
- bind two controls
## registering view

urls.py:

```
    from django.conf.urls import patterns, url
    urlpatterns = patterns(
        ...
        url('^dependent_options/$', 'dependent_options', name='dependent_options'),
    )
```
## creating view

Now it understands `parent_parameter_selector` parameter.
views.py:

```
def dependent_options(request):
    filter_query = Q()
    if request.GET.get('parent_parameter_selector'):
        filter_query &= Q(parent_parameter=request.GET.getlist('parent_parameter_selector'))

    result = {
        'results': [
            {
                'text': instance.title,
                'id': instance.pk
            } for instance in MyModel.objects.filter(filter_query).distinct().order_by('title')
        ],
        'more': True
    }

    return HttpResponse(json.dumps(result), content_type='application/json')
```
## customizing form

Define a `class` attribute for future reference in independent control. Create a reference for this control in dependent control through `data-chain-parent` attribute. 
forms.py:

```
class MyForm(forms.Form):
    parent_model_field = forms.ModelChoiceField(
        label=u"Parent Field",
        widget=ModelSelect2Widget(
            search_fields=['title__icontains'],
            attrs={
                'required': u'true',
                'class': 'parent_parameter_selector'
            }
        )
    )

    child_model_field = forms.ModelChoiceField(
        label=u"Child Field",
        widget=ModelSelect2Widget(
            data_url='/dependent_options/',
            search_fields=['title__icontains'],
            attrs={
                'required': u'true',
                'data-chain-parent': 'parent_parameter_selector'
            }
        )
    )

```
