### PR TITLE
Fix build_attrs() params to support Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ env:
   - TOXENV=qa
   - TOXENV=docs
   - DJANGO=18
-  - DJANGO=19
   - DJANGO=110
+  - DJANGO=111
   - DJANGO=master
 matrix:
   fast_finish: true

--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -73,9 +73,9 @@ class Select2Mixin(object):
     form media.
     """
 
-    def build_attrs(self, extra_attrs=None, **kwargs):
+    def build_attrs(self, *args, **kwargs):
         """Add select2 data attributes."""
-        attrs = super(Select2Mixin, self).build_attrs(extra_attrs=extra_attrs, **kwargs)
+        attrs = super(Select2Mixin, self).build_attrs(*args, **kwargs)
         if self.is_required:
             attrs.setdefault('data-allow-clear', 'false')
         else:
@@ -113,12 +113,12 @@ class Select2Mixin(object):
 class Select2TagMixin(object):
     """Mixin to add select2 tag functionality."""
 
-    def build_attrs(self, extra_attrs=None, **kwargs):
+    def build_attrs(self, *args, **kwargs):
         """Add select2's tag attributes."""
         self.attrs.setdefault('data-minimum-input-length', 1)
         self.attrs.setdefault('data-tags', 'true')
         self.attrs.setdefault('data-token-separators', '[",", " "]')
-        return super(Select2TagMixin, self).build_attrs(extra_attrs, **kwargs)
+        return super(Select2TagMixin, self).build_attrs(*args, **kwargs)
 
 
 class Select2Widget(Select2Mixin, forms.Select):
@@ -197,9 +197,9 @@ class HeavySelect2Mixin(object):
             return self.data_url
         return reverse(self.data_view)
 
-    def build_attrs(self, extra_attrs=None, **kwargs):
+    def build_attrs(self, *args, **kwargs):
         """Set select2's AJAX attributes."""
-        attrs = super(HeavySelect2Mixin, self).build_attrs(extra_attrs=extra_attrs, **kwargs)
+        attrs = super(HeavySelect2Mixin, self).build_attrs(*args, **kwargs)
 
         # encrypt instance Id
         self.widget_id = signing.dumps(id(self))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36}-dj{18,19,110,master},qa,docs
+envlist = py{27,35,36}-dj{18,110,111,master},qa,docs
 [testenv]
 setenv=
     DISPLAY=:99.0
@@ -7,8 +7,8 @@ setenv=
 deps=
     -rrequirements-dev.txt
     dj18: https://github.com/django/django/archive/stable/1.8.x.tar.gz#egg=django
-    dj19: https://github.com/django/django/archive/stable/1.9.x.tar.gz#egg=django
     dj110: https://github.com/django/django/archive/stable/1.10.x.tar.gz#egg=django
+    dj111: https://github.com/django/django/archive/stable/1.11.x.tar.gz#egg=django
     djmaster: https://github.com/django/django/archive/master.tar.gz#egg=django
 commands=
     coverage run --source=django_select2 -m 'pytest' \


### PR DESCRIPTION
This PR overrides #343 and adds testing support in `tox.ini`