### PR TITLE
fixes dependent fields when they are used inline in the admin

### DIFF
--- a/django_select2/static/django_select2/django_select2.js
+++ b/django_select2/static/django_select2/django_select2.js
@@ -4,6 +4,11 @@
   }
 
   var initHeavy = function ($element, options) {
+    var elemPrefix = '';
+    var prefixRe = /.*\-\d+\-/;
+    if (prefixRe.test($element.context.id)) {
+      elemPrefix = prefixRe.exec($element.context.id)[0].replace('id_', '');
+    }
     var settings = $.extend({
       ajax: {
         data: function (params) {
@@ -17,7 +22,8 @@
           if (dependentFields) {
             dependentFields = dependentFields.trim().split(/\s+/)
             $.each(dependentFields, function (i, dependentField) {
-              result[dependentField] = $('[name=' + dependentField + ']', $element.closest('form')).val()
+              var dependentFieldName = elemPrefix + dependentField;
+              result[dependentField] = $('[name=' + dependentFieldName + ']', $element.closest('form')).val()
             })
           }
 


### PR DESCRIPTION
I found a problem with dependent_fields when using django-select2 as an inline admin form.  The result is that the select options are never updated to filter based on the dependent field.

Currently the JS gets the dependent form field's value using:
`$('[name=' + dependentField + ']', $element.closest('form')).val()`.

This works in normal cases because the name attribute of the field will match the field's name.

However, when this feature used as an inline form on an admin page it fails.  
In this case the name attribute of the dependent field element follows is of this pattern:
 `<model_related_name>-<inline-index#>-<dependentField>`.


This fix handles both cases.