### PR TITLE
fix: dependent fields do not work when the form is an inline admin form

### DIFF
--- a/django_select2/static/django_select2/django_select2.js
+++ b/django_select2/static/django_select2/django_select2.js
@@ -12,12 +12,19 @@
             page: params.page,
             field_id: $element.data('field_id')
           }
-
+          var namePrefix = $element.closest('div.inline-related').attr('id')
+          var elementId = $element.attr('id')
+          if (namePrefix && elementId && elementId.indexOf(namePrefix) !== -1) {
+            // in case the prefix if failed to fetch correctly reset it
+            namePrefix += '-'
+          } else {
+            namePrefix = ''
+          }
           var dependentFields = $element.data('select2-dependent-fields')
           if (dependentFields) {
             dependentFields = dependentFields.trim().split(/\s+/)
             $.each(dependentFields, function (i, dependentField) {
-              result[dependentField] = $('[name=' + dependentField + ']', $element.closest('form')).val()
+              result[dependentField] = $('[name=' + namePrefix + dependentField + ']', $element.closest('form')).val()
             })
           }
 


### PR DESCRIPTION
resolves #380

I have the `inline-related` class name hard coded but even then it is less hackish.