### PR TITLE
Convert 'label_from_instance' to staticmethod

### DIFF
--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -504,7 +504,8 @@ class ModelSelect2Mixin(object):
             output.append(self.render_option(selected_choices, option_value, option_label))
         return '\n'.join(output)
 
-    def label_from_instance(self, obj):
+    @staticmethod
+    def label_from_instance(obj):
         """
         Return option label representation from instance.
 


### PR DESCRIPTION
This is a very minor diff, but I was overriding the `label_from_instance` method and noticed that the comment [here](https://github.com/applegrew/django-select2/blob/master/django_select2/forms.py#L516) was a bit misleading as the function signature is missing `self`, so it will actually throw an error if copied verbatim.

However, as the function is so simple and only relies on the `obj` arg to do all its labour it also seems like it can be cleanly converted to a `@staticmethod`.

This will also make correct the lack of a `self` in the comment. Cheers!