### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,3 +22,6 @@ skip = manage.py,docs,.tox,env
 known_first_party = django_select2, tests
 known_third_party = django
 combine_as_imports = true
+
+[bdist_rpm]
+requires = python-django-appconf >= 0.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,4 +24,4 @@ known_third_party = django
 combine_as_imports = true
 
 [bdist_rpm]
-requires = python-django-appconf >= 0.6.0
+requires = python-django-appconf >= 0.6


### PR DESCRIPTION
not all build systems running `python setup.py bdist_rpm`  will generate a setup.cfg if one is already present
so we need to repeat the dependencies from setup.py in setup.cfg's bdist_rpm section if we want to create correct dependencies  in the rpm's generated. (django appconf 0.6 is called python-django-appconf in redhat/centos/fedora)