### PR TITLE
Fallback i18n js files for zh-hans/zh-hant.

### DIFF
--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -99,8 +99,17 @@ class Select2Mixin(object):
             https://docs.djangoproject.com/en/1.8/topics/forms/media/#media-as-a-dynamic-property
         """
         try:
+            # Values in this dict had been removed from Django as language_code in favor of the keys
+            known_fallback_map = {
+                "zh-hans": "zh-cn",
+                "zh-hant": "zh-tw",
+            }
+
+            lang = get_language()
+            lang = known_fallback_map.get(lang, lang)
+
             # get_language() will always return a lower case language code, where some files are named upper case.
-            i = [x.lower() for x in settings.SELECT2_I18N_AVAILABLE_LANGUAGES].index(get_language())
+            i = [x.lower() for x in settings.SELECT2_I18N_AVAILABLE_LANGUAGES].index(lang)
             i18n_file = ('%s/%s.js' % (settings.SELECT2_I18N_PATH, settings.SELECT2_I18N_AVAILABLE_LANGUAGES[i]), )
         except ValueError:
             i18n_file = ()

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -129,6 +129,8 @@ class TestSelect2Mixin(object):
             'django_select2/django_select2.js'
         )
 
+        pytest.importorskip("django", minversion="2.0.4")
+
         translation.activate('zh-hans')
         assert tuple(Select2Widget().media._js) == (
             '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js',

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -129,10 +129,17 @@ class TestSelect2Mixin(object):
             'django_select2/django_select2.js'
         )
 
-        translation.activate('zh-cn')
+        translation.activate('zh-hans')
         assert tuple(Select2Widget().media._js) == (
             '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js',
             '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/i18n/zh-CN.js',
+            'django_select2/django_select2.js'
+        )
+
+        translation.activate('zh-hant')
+        assert tuple(Select2Widget().media._js) == (
+            '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js',
+            '//cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/i18n/zh-TW.js',
             'django_select2/django_select2.js'
         )
 


### PR DESCRIPTION
Since Django 1.9, `zh-cn` and `zh-tw` had been [replaced](https://docs.djangoproject.com/en/2.0/internals/deprecation/#deprecation-removed-in-1-9) by `zh-hans` and `zh-hant`, respectively.