### PR TITLE
Fix typo in docstring ChoicesField -> ChoiceField

### DIFF
--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -277,7 +277,7 @@ class HeavySelect2Widget(HeavySelect2Mixin, Select2Widget):
     or::
 
         class MyForm(forms.Form):
-            my_field = forms.ChoicesField(
+            my_field = forms.ChoiceField(
                 widget=HeavySelect2Widget(
                     data_url='/url/to/json/response'
                 )


### PR DESCRIPTION
It's `django.forms.ChoiceField`, not `django.forms.ChoicesField`.

Used correctly here: 
https://github.com/applegrew/django-select2/blob/a9aa31146f44017848451178123268e38c9def38/django_select2/forms.py#L143