### PR TITLE
optionally don't include JS/CSS of select2

### DIFF
--- a/django_select2/conf.py
+++ b/django_select2/conf.py
@@ -62,6 +62,11 @@ class Select2Conf(AppConf):
 
         SELECT2_JS = 'assets/js/select2.min.js'
 
+    If you provide your own JS and would not like Django-Select2 to load any, change
+    this setting to a blank string like so::
+
+        SELECT2_JS = ''
+
     .. tip:: Change this setting to a local asset in your development environment to
         develop without an Internet connection.
     """
@@ -74,6 +79,11 @@ class Select2Conf(AppConf):
     the local 'static' resources, add a line to your settings.py like so::
 
         SELECT2_CSS = 'assets/css/select2.css'
+
+    If you provide your own CSS and would not like Django-Select2 to load any, change
+    this setting to a blank string like so::
+
+        SELECT2_CSS = ''
 
     .. tip:: Change this setting to a local asset in your development environment to
         develop without an Internet connection.

--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -96,7 +96,7 @@ class Select2Mixin(object):
         Construct Media as a dynamic property.
 
         .. Note:: For more information visit
-            https://docs.djangoproject.com/en/1.8/topics/forms/media/#media-as-a-dynamic-property
+            https://docs.djangoproject.com/en/stable/topics/forms/media/#media-as-a-dynamic-property
         """
         try:
             # get_language() will always return a lower case language code, where some files are named upper case.

--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -104,9 +104,11 @@ class Select2Mixin(object):
             i18n_file = ('%s/%s.js' % (settings.SELECT2_I18N_PATH, settings.SELECT2_I18N_AVAILABLE_LANGUAGES[i]), )
         except ValueError:
             i18n_file = ()
+        select2_js = (settings.SELECT2_JS,) if settings.SELECT2_JS else (,)
+        select2_css = (settings.SELECT2_CSS,) if settings.SELECT2_CSS else (,)
         return forms.Media(
-            js=(settings.SELECT2_JS,) + i18n_file + ('django_select2/django_select2.js',),
-            css={'screen': (settings.SELECT2_CSS,)}
+            js=select2_js + i18n_file + ('django_select2/django_select2.js',),
+            css={'screen': select2_css}
         )
 
     media = property(_get_media)

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -152,11 +152,23 @@ class TestSelect2MixinSettings(object):
         assert 'alternate.js' in result
         assert 'django_select2/django_select2.js' in result
 
+    def test_empty_js_setting(self, settings):
+        settings.SELECT2_JS = ''
+        sut = Select2Widget()
+        result = sut.media.render()
+        assert 'django_select2/django_select2.js' in result
+
     def test_css_setting(self, settings):
         settings.SELECT2_CSS = 'alternate.css'
         sut = Select2Widget()
         result = sut.media.render()
         assert 'alternate.css' in result
+
+    def test_empty_css_setting(self, settings):
+        settings.SELECT2_CSS = ''
+        sut = Select2Widget()
+        result = sut.media.render()
+        assert '.css' not in result
 
 
 class TestHeavySelect2Mixin(TestSelect2Mixin):


### PR DESCRIPTION
Hi, thanks for your great work with this package! 

Would you consider adding the option of not including the select2 JS/CSS at all in your plugin? I have a project where we include that elsewhere, so we've set the SELECT2_CSS and SELECT2_JS variables to an empty string. Ideally the package wouldn't try to load a file at all, though, because this throws errors both client-side and on our Nginx server when the browser tries to load /static/

https://github.com/attendanceproject/djattendance/blob/dev/ap/ap/settings/base.py#L421-L422