### PR TITLE
Add support for custom to_field names for foreign keys

### DIFF
--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -433,11 +433,12 @@ class ModelSelect2Mixin(object):
             c for c in selected_choices
             if c not in self.choices.field.empty_values
         }
-        choices = (
-            (obj.pk, self.label_from_instance(obj))
-            for obj in self.choices.queryset.filter(pk__in=selected_choices)
-        )
-        for option_value, option_label in choices:
+        field_name = self.choices.field.to_field_name or 'pk'
+        query = Q(**{'%s__in' % field_name: selected_choices})
+        for obj in self.choices.queryset.filter(query):
+            option_value = self.choices.choice(obj)[0]
+            option_label = self.label_from_instance(obj)
+
             selected = (
                 str(option_value) in value and
                 (has_selected is False or self.allow_multiple_selected)

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -5,6 +5,7 @@ import os
 import pytest
 from django.core import signing
 from django.db.models import QuerySet
+from django.forms import ModelChoiceField
 from django.utils import translation
 from django.utils.encoding import force_text
 from django.utils.six import text_type
@@ -22,7 +23,7 @@ from tests.testapp import forms
 from tests.testapp.forms import (
     NUMBER_CHOICES, HeavySelect2MultipleWidgetForm, TitleModelSelect2Widget
 )
-from tests.testapp.models import City, Country, Genre
+from tests.testapp.models import Artist, City, Country, Genre, Groupie
 
 try:
     from django.urls import reverse
@@ -352,6 +353,12 @@ class TestModelSelect2Mixin(TestHeavySelect2Mixin):
     def test_get_url(self):
         widget = ModelSelect2Widget(queryset=Genre.objects.all(), search_fields=['title__icontains'])
         assert isinstance(widget.get_url(), text_type)
+
+    def test_custom_to_field_name(self):
+        the_best_band_in_the_world = Artist.objects.create(title='Take That')
+        groupie = Groupie.objects.create(obsession=the_best_band_in_the_world)
+        form = forms.GroupieForm(instance=groupie)
+        assert '<option value="Take That" selected>TAKE THAT</option>' in form.as_p()
 
 
 class TestHeavySelect2TagWidget(TestHeavySelect2Mixin):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -5,7 +5,6 @@ import os
 import pytest
 from django.core import signing
 from django.db.models import QuerySet
-from django.forms import ModelChoiceField
 from django.utils import translation
 from django.utils.encoding import force_text
 from django.utils.six import text_type

--- a/tests/testapp/forms.py
+++ b/tests/testapp/forms.py
@@ -195,3 +195,12 @@ class AddressChainedSelect2WidgetForm(forms.Form):
             max_results=500,
         )
     )
+
+
+class GroupieForm(forms.ModelForm):
+    class Meta:
+        model = models.Groupie
+        fields = '__all__'
+        widgets = {
+            'obsession': ArtistCustomTitleWidget
+        }

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -12,7 +12,7 @@ class Genre(models.Model):
 
 
 class Artist(models.Model):
-    title = models.CharField(max_length=50)
+    title = models.CharField(max_length=50, unique=True)
     genres = models.ManyToManyField(Genre)
 
     class Meta:
@@ -56,3 +56,7 @@ class City(models.Model):
 
     def __str__(self):
         return self.name
+
+
+class Groupie(models.Model):
+    obsession = models.ForeignKey(Artist, to_field='title', on_delete=models.CASCADE)


### PR DESCRIPTION
Django's ForeignKey supports custom to_fields. The to field is the
primary key by default, but can be modified. The to field is also
used by forms to reduce database lookups.

This patch add support for custom to_field names on both model or
form layer.