### PR TITLE
Instantiate select2 on newly created inlines

### DIFF
--- a/django_select2/static/django_select2/django_select2.js
+++ b/django_select2/static/django_select2/django_select2.js
@@ -52,5 +52,15 @@
 
   $(function () {
     $('.django-select2').djangoSelect2()
+
+    django.jQuery(document).on('formset:added', function (event, $row, formsetName) {
+      // Converting to the "normal jQuery"
+      var jqRow = jQuery($row)
+
+      // Because select2 was already instantiated on the empty form, we need to remove it and
+      // re-instantiate it.
+      jqRow.find('.select2-container').remove()
+      jqRow.find('.django-select2').djangoSelect2()
+    })
   })
 }(this.jQuery))


### PR DESCRIPTION
This fix a very long and trailing issue for maybe 3 years ?!? 
Thanks for implementing select2 in Django 2;
However for people still on the LTS version 1.11 (like myself), this plugin not working with inlines might be an issue.

Feel free to accept the PR if you want.
My IDE formatted the js file making it look like there was huge changes when in fact only added from line:56.

Thanks.