### PR TITLE
Fix media merge order on Django 2.0.8

### DIFF
--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -98,6 +98,7 @@ class Select2Mixin(object):
         .. Note:: For more information visit
             https://docs.djangoproject.com/en/stable/topics/forms/media/#media-as-a-dynamic-property
         """
+        extra = '' if settings.DEBUG else '.min'
         lang = get_language()
         i18n_name = None
         select2_js = (settings.SELECT2_JS,) if settings.SELECT2_JS else ()
@@ -119,7 +120,12 @@ class Select2Mixin(object):
         i18n_file = ('%s/%s.js' % (settings.SELECT2_I18N_PATH, i18n_name),) if i18n_name else ()
 
         return forms.Media(
-            js=select2_js + i18n_file + ('django_select2/django_select2.js',),
+            js=(
+                'admin/js/vendor/jquery/jquery%s.js' % extra,
+            ) + select2_js + i18n_file + (
+                'django_select2/django_select2.js',
+                'admin/js/jquery.init.js',
+            ),
             css={'screen': select2_css}
         )
 


### PR DESCRIPTION
Django 2.x changed the way media resources are merged.
https://docs.djangoproject.com/en/2.1/topics/forms/media/#order-of-assets

>Changed in Django 2.0:
>In older versions, the assets of Media objects are concatenated rather than merged in a way that >tries to preserve the relative ordering of the elements in each list.

Now it is quite possible to run into situation when jquery will be included later than needed.

Similar issue:
https://github.com/yourlabs/django-autocomplete-light/issues/959
and how it was resolved:
https://github.com/yourlabs/django-autocomplete-light/blob/master/src/dal_select2/widgets.py#L50

Here how it is done by django itself:
https://github.com/django/django/blob/master/django/contrib/admin/widgets.py#L440

It appears to me that every widget should include dependencies all along with media. This way new merging mechanic will work correctly.

Happy to discuss, would be nice to have this fix upstream so we don't need to support own fork.