### PR TITLE
Make the inclusion of local django_select2.js optional: (#484, #479)

### DIFF
--- a/django_select2/conf.py
+++ b/django_select2/conf.py
@@ -74,6 +74,15 @@ class Select2Conf(AppConf):
         develop without an Internet connection.
     """
 
+    DJANGO_JS = 'django_select2/django_select2.js'
+    """
+    If you provide django_select2.js through an alternative means (e.g. NPM + Webpack), change 
+    this setting to a blank string like so:
+    
+      SELECT2_DJANGO_JS = ''  #note that we transpose 'django' and 'select2' for consistency with the META prefix (below)
+     
+    """
+
     CSS = '//cdnjs.cloudflare.com/ajax/libs/select2/{version}/css/select2.min.css'.format(version=LIB_VERSION)
     """
     The URI for the Select2 CSS file. By default this points to the Cloudflare CDN.

--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -101,6 +101,7 @@ class Select2Mixin(object):
         lang = get_language()
         i18n_name = None
         select2_js = (settings.SELECT2_JS,) if settings.SELECT2_JS else ()
+        select2_django_js = (settings.SELECT2_DJANGO_JS,) if settings.SELECT2_DJANGO_JS else ()
         select2_css = (settings.SELECT2_CSS,) if settings.SELECT2_CSS else ()
 
         try:
@@ -119,7 +120,7 @@ class Select2Mixin(object):
         i18n_file = ('%s/%s.js' % (settings.SELECT2_I18N_PATH, i18n_name),) if i18n_name else ()
 
         return forms.Media(
-            js=select2_js + i18n_file + ('django_select2/django_select2.js',),
+            js=select2_js + i18n_file + select2_django_js,
             css={'screen': select2_css}
         )
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -169,9 +169,11 @@ class TestSelect2MixinSettings(object):
         assert 'django_select2/django_select2.js' in result
 
     def test_empty_django_js_setting(self, settings):
+        """ #520 """
         settings.SELECT2_DJANGO_JS = ''
         sut = Select2Widget()
         result = sut.media.render()
+        # TODO: django_select2.js should not not be hard-coded.
         assert not 'django_select2/django_select2.js' in result
 
     def test_css_setting(self, settings):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -168,6 +168,12 @@ class TestSelect2MixinSettings(object):
         result = sut.media.render()
         assert 'django_select2/django_select2.js' in result
 
+    def test_empty_django_js_setting(self, settings):
+        settings.SELECT2_DJANGO_JS = ''
+        sut = Select2Widget()
+        result = sut.media.render()
+        assert not 'django_select2/django_select2.js' in result
+
     def test_css_setting(self, settings):
         settings.SELECT2_CSS = 'alternate.css'
         sut = Select2Widget()


### PR DESCRIPTION
In #479, you published the django-select2 JS to NPM
In #484, you provided the option to exclude the Select2 JS from the Select2Mixin class in forms.py

It would seem to follow that we would like the option to exclude the django-select2 JS in a similar manner, e.g. because we want to provide it via npm and our bundler.