### PR TITLE
Clear dependent fields on select

### DIFF
--- a/django_select2/static/django_select2/django_select2.js
+++ b/django_select2/static/django_select2/django_select2.js
@@ -57,11 +57,11 @@
       } else {
         init($element, settings)
       }
-      $element.on("select2:select", function (e) {
-          var name = $(e.currentTarget).attr("name")
-          $("[data-select2-dependent-fields=" + name + "]").each(function () {
-              $(this).val('').trigger('change')
-          })
+      $element.on('select2:select', function (e) {
+        var name = $(e.currentTarget).attr('name')
+        $('[data-select2-dependent-fields=' + name + ']').each(function () {
+          $(this).val('').trigger('change')
+        })
       })
     })
     return this

--- a/django_select2/static/django_select2/django_select2.js
+++ b/django_select2/static/django_select2/django_select2.js
@@ -57,6 +57,12 @@
       } else {
         init($element, settings)
       }
+      $element.on("select2:select", function (e) {
+          var name = $(e.currentTarget).attr("name")
+          $("[data-select2-dependent-fields=" + name + "]").each(function () {
+              $(this).val('').trigger('change')
+          })
+      })
     })
     return this
   }


### PR DESCRIPTION
Add simple reset of dependent fields when changing the parent.

This could be recursive to clear the child or children, I just haven't had this issue yet.

This can fix #388 