### PR TITLE
Prevent having "None" in the placeholder

### DIFF
--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -80,7 +80,7 @@ class Select2Mixin:
             default_attrs['data-allow-clear'] = 'false'
         else:
             default_attrs['data-allow-clear'] = 'true'
-            default_attrs['data-placeholder'] = self.empty_label
+            default_attrs['data-placeholder'] = self.empty_label or ""
 
         default_attrs.update(base_attrs)
         attrs = super().build_attrs(default_attrs, extra_attrs=extra_attrs)
@@ -345,7 +345,7 @@ class ModelSelect2Mixin:
 
     @property
     def empty_label(self):
-        if isinstance(self.choices, ModelChoiceIterator) and self.choices.field.empty_label:
+        if isinstance(self.choices, ModelChoiceIterator):
             return self.choices.field.empty_label
         return ''
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -95,7 +95,9 @@ class TestSelect2Mixin:
         multiple_select = self.multiple_form.fields['featured_artists']
         assert multiple_select.required is False
         assert multiple_select.widget.allow_multiple_selected
-        assert '<option value=""></option>' not in multiple_select.widget.render('featured_artists', None)
+        output = multiple_select.widget.render('featured_artists', None)
+        assert '<option value=""></option>' not in output
+        assert 'data-placeholder=""' in output
 
     def test_i18n(self):
         translation.activate('de')


### PR DESCRIPTION
I had None set as a placeholder on my ModelSelect2MultipleWidget because I initialize the widget through the Meta class of my form and I don't explicitly set the empty_label on my field.

So I think it should check if the empty_label is set before assigning it to the placeholder.

This issue is linked to #565 