### PR TITLE
Change signing to uuid for create widget_id

### DIFF
--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -221,6 +221,7 @@ class HeavySelect2Mixin:
             self.attrs = {}
 
         self.uuid = str(uuid.uuid4())
+        self.field_id = signing.dumps(self.uuid)
         self.data_view = kwargs.pop('data_view', None)
         self.data_url = kwargs.pop('data_url', None)
 
@@ -253,9 +254,7 @@ class HeavySelect2Mixin:
 
         attrs = super().build_attrs(default_attrs, extra_attrs=extra_attrs)
 
-        self.widget_id = signing.dumps(self.uuid)
-
-        attrs['data-field_id'] = self.widget_id
+        attrs['data-field_id'] = self.field_id
 
         attrs['class'] += ' django-select2-heavy'
         return attrs

--- a/django_select2/forms.py
+++ b/django_select2/forms.py
@@ -46,6 +46,7 @@ in their names.
     :parts: 1
 
 """
+import uuid
 from functools import reduce
 from itertools import chain
 from pickle import PicklingError  # nosec
@@ -219,6 +220,7 @@ class HeavySelect2Mixin:
         else:
             self.attrs = {}
 
+        self.uuid = str(uuid.uuid4())
         self.data_view = kwargs.pop('data_view', None)
         self.data_url = kwargs.pop('data_url', None)
 
@@ -251,8 +253,7 @@ class HeavySelect2Mixin:
 
         attrs = super().build_attrs(default_attrs, extra_attrs=extra_attrs)
 
-        # encrypt instance Id
-        self.widget_id = signing.dumps(id(self))
+        self.widget_id = signing.dumps(self.uuid)
 
         attrs['data-field_id'] = self.widget_id
 
@@ -261,12 +262,12 @@ class HeavySelect2Mixin:
 
     def render(self, *args, **kwargs):
         """Render widget and register it in Django's cache."""
-        output = super(HeavySelect2Mixin, self).render(*args, **kwargs)
+        output = super().render(*args, **kwargs)
         self.set_to_cache()
         return output
 
     def _get_cache_key(self):
-        return "%s%s" % (settings.SELECT2_CACHE_PREFIX, id(self))
+        return "%s%s" % (settings.SELECT2_CACHE_PREFIX, self.uuid)
 
     def set_to_cache(self):
         """

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -388,7 +388,7 @@ class TestModelSelect2Mixin(TestHeavySelect2Mixin):
         widget.render('name', 'value')
         url = reverse('django_select2:auto-json')
         genre = Genre.objects.last()
-        response = client.get(url, data=dict(field_id=widget.widget_id,
+        response = client.get(url, data=dict(field_id=widget.field_id,
                                              term=genre.title))
         assert response.status_code == 200, response.content
         data = json.loads(response.content.decode('utf-8'))

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -3,7 +3,6 @@ import os
 from collections.abc import Iterable
 
 import pytest
-from django.core import signing
 from django.db.models import QuerySet
 from django.urls import reverse
 from django.utils import translation
@@ -384,11 +383,13 @@ class TestModelSelect2Mixin(TestHeavySelect2Mixin):
         assert result.exists()
 
     def test_ajax_view_registration(self, client):
-        widget = ModelSelect2Widget(queryset=Genre.objects.all(), search_fields=['title__icontains'])
+        widget = ModelSelect2Widget(queryset=Genre.objects.all(),
+                                    search_fields=['title__icontains'])
         widget.render('name', 'value')
         url = reverse('django_select2:auto-json')
         genre = Genre.objects.last()
-        response = client.get(url, data=dict(field_id=signing.dumps(id(widget)), term=genre.title))
+        response = client.get(url, data=dict(field_id=widget.widget_id,
+                                             term=genre.title))
         assert response.status_code == 200, response.content
         data = json.loads(response.content.decode('utf-8'))
         assert data['results']

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -20,7 +20,7 @@ class TestAutoResponseView:
         artist = artists[0]
         form = AlbumModelSelect2WidgetForm()
         assert form.as_p()
-        field_id = form.fields['artist'].widget.widget_id
+        field_id = form.fields['artist'].widget.field_id
         url = reverse('django_select2:auto-json')
         response = client.get(url, {'field_id': field_id, 'term': artist.title})
         assert response.status_code == 200
@@ -55,7 +55,7 @@ class TestAutoResponseView:
             search_fields=['title__icontains']
         )
         widget.render('name', None)
-        field_id = widget.widget_id
+        field_id = widget.field_id
 
         response = client.get(url, {'field_id': field_id, 'term': ''})
         assert response.status_code == 200
@@ -76,7 +76,7 @@ class TestAutoResponseView:
         form = AlbumModelSelect2WidgetForm()
         form.fields['artist'].widget = ArtistCustomTitleWidget()
         assert form.as_p()
-        field_id = form.fields['artist'].widget.widget_id
+        field_id = form.fields['artist'].widget.field_id
 
         artist = artists[0]
         response = client.get(url, {'field_id': field_id, 'term': artist.title})
@@ -90,7 +90,7 @@ class TestAutoResponseView:
         artist = artists[0]
         form = AlbumModelSelect2WidgetForm()
         assert form.as_p()
-        field_id = form.fields['artist'].widget.widget_id
+        field_id = form.fields['artist'].widget.field_id
         cache_key = form.fields['artist'].widget._get_cache_key()
         widget_dict = cache.get(cache_key)
         widget_dict['url'] = 'yet/another/url'

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,6 +1,5 @@
 import json
 
-from django.core import signing
 from django.utils.encoding import smart_str
 
 from django_select2.cache import cache
@@ -21,7 +20,7 @@ class TestAutoResponseView:
         artist = artists[0]
         form = AlbumModelSelect2WidgetForm()
         assert form.as_p()
-        field_id = signing.dumps(id(form.fields['artist'].widget))
+        field_id = form.fields['artist'].widget.widget_id
         url = reverse('django_select2:auto-json')
         response = client.get(url, {'field_id': field_id, 'term': artist.title})
         assert response.status_code == 200
@@ -43,7 +42,7 @@ class TestAutoResponseView:
 
     def test_field_id_not_found(self, client, artists):
         artist = artists[0]
-        field_id = signing.dumps(123456789)
+        field_id = 'not-exists'
         url = reverse('django_select2:auto-json')
         response = client.get(url, {'field_id': field_id, 'term': artist.title})
         assert response.status_code == 404
@@ -56,7 +55,7 @@ class TestAutoResponseView:
             search_fields=['title__icontains']
         )
         widget.render('name', None)
-        field_id = signing.dumps(id(widget))
+        field_id = widget.widget_id
 
         response = client.get(url, {'field_id': field_id, 'term': ''})
         assert response.status_code == 200
@@ -77,7 +76,7 @@ class TestAutoResponseView:
         form = AlbumModelSelect2WidgetForm()
         form.fields['artist'].widget = ArtistCustomTitleWidget()
         assert form.as_p()
-        field_id = signing.dumps(id(form.fields['artist'].widget))
+        field_id = form.fields['artist'].widget.widget_id
 
         artist = artists[0]
         response = client.get(url, {'field_id': field_id, 'term': artist.title})
@@ -91,7 +90,7 @@ class TestAutoResponseView:
         artist = artists[0]
         form = AlbumModelSelect2WidgetForm()
         assert form.as_p()
-        field_id = signing.dumps(id(form.fields['artist'].widget))
+        field_id = form.fields['artist'].widget.widget_id
         cache_key = form.fields['artist'].widget._get_cache_key()
         widget_dict = cache.get(cache_key)
         widget_dict['url'] = 'yet/another/url'


### PR DESCRIPTION
Resolves: #581 

This PR has the objective of creating a `widget_id` using a `uuid`. 
This decreases the chances of the keys overlapping when saving to the cache.